### PR TITLE
Return write response to main() function

### DIFF
--- a/index_setsm.py
+++ b/index_setsm.py
@@ -310,7 +310,11 @@ def main():
         if args.write_json:
             write_to_json(dst, groups, total, args)
         else:
-            write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pairs, total, db_path_prefix, fld_defs, args)
+            write_result = write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pairs, total, db_path_prefix, fld_defs, args)
+            if write_result:
+                return True
+            else:
+                return False
 
 
 def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pairs, total, db_path_prefix, fld_defs, args):


### PR DESCRIPTION
Allow main() function to return status of OGR layer writing. This is necessary when calling index_setsm.py externally from another script to handle exceptions. 