### PR TITLE
always exit with system-readable status code

### DIFF
--- a/index_setsm.py
+++ b/index_setsm.py
@@ -226,7 +226,7 @@ def main():
                     ogrDriver.DeleteDataSource(dst_ds)
             elif not args.append:
                 logger.error("Dst shapefile exists.  Use the --overwrite or --append options.")
-                sys.exit()
+                sys.exit(-1)
 
 
         if ogr_driver_str == 'FileGDB' and os.path.isdir(dst_ds):
@@ -242,7 +242,7 @@ def main():
                             break
                         elif not args.append:
                             logger.error("Dst GDB layer exists.  Use the --overwrite or --append options.")
-                            sys.exit()
+                            sys.exit(-1)
                 ds = None
 
         ## Postgres check - do not overwrite
@@ -259,7 +259,7 @@ def main():
                             break
                         elif not args.append:
                             logger.error("Dst DB layer exists.  Use the --overwrite or --append options.")
-                            sys.exit()
+                            sys.exit(-1)
                 ds = None
 
 
@@ -312,9 +312,9 @@ def main():
         else:
             write_result = write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pairs, total, db_path_prefix, fld_defs, args)
             if write_result:
-                return True
+                sys.exit(0)
             else:
-                return False
+                sys.exit(-1)
 
 
 def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pairs, total, db_path_prefix, fld_defs, args):
@@ -581,16 +581,16 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
         else:
             logger.error('Cannot open layer: {}'.format(dst_lyr))
             ds = None
-            return False
+            sys.exit(-1)
 
         ds = None
 
     else:
         logger.info("Cannot open dataset: {}".format(dst_ds))
-        return False
+        sys.exit(-1)
 
     logger.info("Done")
-    return True
+    sys.exit(0)
 
 
 def read_json(json_fp, mode):


### PR DESCRIPTION
The original intent with PR #2 and PR #3 was to make this index_setsm.py importable to other repos, so indexing could happen after a number of conditions were met. However, the library requirements for this repo (Python GDAL, with psql and SSL support) vary significantly from our other PGC-specific GDAL builds, making it not possible to import. 

This PR simply changes any script exit condition to respond with sys.exit(0) upon success, and sys.exit(-1) upon failure (instead of 'return True' or 'return False'). This makes response handling possible in shell (e.g., bash) as well as being imported in Python (will throw SystemExit exception). 