### PR TITLE
Incorporate downsampled products; make stripDEM changes

### DIFF
--- a/index_setsm.py
+++ b/index_setsm.py
@@ -128,7 +128,7 @@ def main():
         parser.error('--search-masked cannot be used with the --write-json or --read-json options')
 
     if args.mode != 'strip' and args.search_masked:
-        parser.error('--search-masked applie donly to mode=strip')
+        parser.error('--search-masked applies only to mode=strip')
 
     ## Check project
     if args.mode == 'tile' and not args.project:

--- a/index_setsm.py
+++ b/index_setsm.py
@@ -618,7 +618,6 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
                                 except Exception as e:
                                     raise e
                                 else:
-                                    print('No exception')
                                     if err.err_level >= gdal.CE_Warning:
                                         raise RuntimeError(err.err_level, err.err_no, err.err_msg)
                                 finally:

--- a/index_setsm.py
+++ b/index_setsm.py
@@ -337,7 +337,7 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
 
     ## Create dataset if it does not exist
     if ogr_driver_str == 'ESRI Shapefile':
-        max_fld_width = 524
+        max_fld_width = 254
         if os.path.isfile(dst_ds):
             ds = ogrDriver.Open(dst_ds,1)
         else:

--- a/lib/dem.py
+++ b/lib/dem.py
@@ -160,18 +160,8 @@ class SetsmScene(object):
             self.get_metafile_info()
 
             ## Build res_str
-            self.res_str = scene_dem_res_lookup[float(self.res)][1]
-            # try:
-            #     res_int = int(self.res)
-            # except ValueError as e:
-            #     res_str = self.res
-            # else:
-            #     if res_int > 0:
-            #         self.res_str = "{}m".format(self.res)
-            #     elif res_int == 0:
-            #         self.res_str = "50cm"
-            #     else:
-            #         raise RuntimeError("Scene has invalid resolution value in name: {}".format(scene.sceneid))
+            scene_dem_resstr_lookup = { a: b for (a,b) in scene_dem_res_lookup.values()}
+            self.res_str = scene_dem_resstr_lookup[self.res]
 
             ## Get version str with ability to handle 1-3 parts of semantic version
             if self.group_version:
@@ -182,17 +172,17 @@ class SetsmScene(object):
             vl = [0,0,0]
             for i in range(len(vp)):
                 vl[i] = int(vp[i])
-            version_str = '{:02}{:02}{:02}'.format(vl[0],vl[1],vl[2])
+            version_str = 'v{:02}{:02}{:02}'.format(vl[0],vl[1],vl[2])
 
             ## Make strip ID
-            self.stripdemid = '{}_{}_v{}'.format(self.pairname, self.res_str, version_str)
+            self.stripdemid = '_'.join((self.pairname, self.res_str, version_str))
 
-            sceneid_resstr, stripid_resstr = scene_dem_res_lookup[self.dsp_dem_res]
-            dsp_sceneid_split = self.sceneid.split('_')[:-1]
-            dsp_sceneid_split.append(sceneid_resstr)
-            self.dsp_sceneid = '_'.join(dsp_sceneid_split)
-            self.dsp_stripdemid = '_'.join((self.pairname, stripid_resstr, version_str))
-
+            if self.is_dsp:
+                sceneid_resstr, stripid_resstr = scene_dem_res_lookup[self.dsp_dem_res]
+                dsp_sceneid_split = self.sceneid.split('_')[:-1]
+                dsp_sceneid_split.append(sceneid_resstr)
+                self.dsp_sceneid = '_'.join(dsp_sceneid_split)
+                self.dsp_stripdemid = '_'.join((self.pairname, stripid_resstr, version_str))
 
     def get_dem_info(self):
 
@@ -387,7 +377,7 @@ class SetsmScene(object):
 
         ## Loop over dict, adding attributes to scene object
         for k in md:
-            setattr(self,k,md[k])
+            setattr(self, k, md[k])
 
         ## Verify presence of key attributes
         for k in self.key_attribs:
@@ -408,6 +398,8 @@ class SetsmScene(object):
         'dem',
         'epsg',
         'id',
+        'is_xtrack',
+        'is_dsp',
         'filesz_dem',
         'filesz_lsf',
         'filesz_mt',
@@ -432,7 +424,7 @@ class SetsmScene(object):
         'srcfn',
         'srcfp',
         'srs',
-        'stripid',
+        'stripdemid',
         'wkt_esri',
         'xres',
         'xsize',
@@ -612,10 +604,10 @@ class SetsmDem(object):
             vl = [0, 0, 0]
             for i in range(len(vp)):
                 vl[i] = int(vp[i])
-            version_str = '{:02}{:02}{:02}'.format(vl[0], vl[1], vl[2])
+            version_str = 'v{:02}{:02}{:02}'.format(vl[0], vl[1], vl[2])
 
             ## Make strip ID
-            self.stripdemid = '{}_{}_v{}'.format(self.pairname, self.res_str, version_str)
+            self.stripdemid = '_'.join((self.pairname, self.res_str, version_str))
 
 
     def compute_density_and_statistics(self):
@@ -1145,11 +1137,13 @@ class SetsmDem(object):
         'filesz_dem',
         'filesz_mt',
         'filesz_or',
+        'filesz_or2',
         'geocell',
         'geom',
         'gtf',
         'id',
         'is_lsf',
+        'is_xtrack',
         'matchtag',
         'mdf',
         'metapath',
@@ -1734,15 +1728,12 @@ class SetsmTile(object):
         'gtf',
         'id',
         'matchtag',
-        'mean_resid_z',
         'metapath',
         'ndv',
         'num_components',
-        'num_gcps',
         'ortho',
         'proj',
         'proj4',
-        'reg_src',
         'regmetapath',
         'res',
         'srcdir',
@@ -1750,7 +1741,6 @@ class SetsmTile(object):
         'srcfp',
         'srs',
         'stats',
-        'sum_gcps',
         'tileid',
         'tilename',
         'wkt_esri',
@@ -1758,6 +1748,10 @@ class SetsmTile(object):
         'xsize',
         'yres',
         'ysize',
+        # 'mean_resid_z',
+        # 'num_gcps',
+        # 'reg_src',
+        # 'sum_gcps',
     )
 
 class RegInfo(object):

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -101,7 +101,7 @@ DEM_ATTRIBUTE_DEFINITIONS_BASIC = [
 ]
 
 DEM_ATTRIBUTE_DEFINITIONS = DEM_ATTRIBUTE_DEFINITIONS_BASIC + [
-    StandardAttribute("LOCATION", ogr.OFTString, 254, 0),
+    StandardAttribute("LOCATION", ogr.OFTString, 512, 0),
     StandardAttribute("FILESZ_DEM", ogr.OFTReal, 0, 0),
     StandardAttribute("FILESZ_MT", ogr.OFTReal, 0, 0),
     StandardAttribute("FILESZ_OR", ogr.OFTReal, 0, 0),
@@ -137,7 +137,7 @@ SCENE_ATTRIBUTE_DEFINITIONS_BASIC = [
 ]
 
 SCENE_ATTRIBUTE_DEFINITIONS = SCENE_ATTRIBUTE_DEFINITIONS_BASIC + [
-    StandardAttribute("LOCATION", ogr.OFTString, 254, 0),
+    StandardAttribute("LOCATION", ogr.OFTString, 512, 0),
     StandardAttribute("FILESZ_DEM", ogr.OFTReal, 0, 0),
     StandardAttribute("FILESZ_LSF", ogr.OFTReal, 0, 0),
     StandardAttribute("FILESZ_MT", ogr.OFTReal, 0, 0),
@@ -162,7 +162,7 @@ TILE_DEM_ATTRIBUTE_DEFINITIONS_BASIC = [
 ]
 
 TILE_DEM_ATTRIBUTE_DEFINITIONS = TILE_DEM_ATTRIBUTE_DEFINITIONS_BASIC + [
-    StandardAttribute("LOCATION", ogr.OFTString, 254, 0),
+    StandardAttribute("LOCATION", ogr.OFTString, 512, 0),
     StandardAttribute("FILESZ_DEM", ogr.OFTReal, 0, 0),
     StandardAttribute("INDEX_DATE", ogr.OFTString, 32, 0),
 ]
@@ -200,7 +200,7 @@ OVERLAP_FILE_ADDITIONAL_ATTRIBUTE_DEFINITIONS = [
     StandardAttribute("REFN_MTHD", ogr.OFTInteger, 8, 0),
     StandardAttribute("ALIGN_MTHD", ogr.OFTString, 64, 0),
     StandardAttribute("HOST", ogr.OFTString, 32, 0),
-    StandardAttribute("SEED_DEM", ogr.OFTString, 254, 0),
+    StandardAttribute("SEED_DEM", ogr.OFTString, 512, 0),
     StandardAttribute("CR_DATE", ogr.OFTString, 32, 0),
     StandardAttribute("RUNTIME", ogr.OFTReal, 0, 0),
     StandardAttribute("DEM_NAME", ogr.OFTString, 254, 0)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -70,6 +70,7 @@ DEM_ATTRIBUTE_DEFINITIONS_BASIC = [
 
     ## Overlap attributes
     StandardAttribute("DEM_ID", ogr.OFTString, 254, 0),
+    StandardAttribute("STRIPDEMID", ogr.OFTString, 254, 0),
     StandardAttribute("PAIRNAME", ogr.OFTString, 64, 0),
     StandardAttribute("SENSOR1", ogr.OFTString, 8, 0),
     StandardAttribute("SENSOR2", ogr.OFTString, 8, 0),
@@ -90,8 +91,20 @@ DEM_ATTRIBUTE_DEFINITIONS_BASIC = [
     StandardAttribute("CR_DATE", ogr.OFTString, 32, 0),
     StandardAttribute("ALGM_VER", ogr.OFTString, 32, 0),
     StandardAttribute("IS_LSF", ogr.OFTInteger, 8, 8),
-    StandardAttribute("REL_VER", ogr.OFTString, 32, 0),
+    StandardAttribute("IS_XTRACK", ogr.OFTInteger, 8, 8),
     StandardAttribute("DENSITY", ogr.OFTReal, 0, 0),
+]
+
+DEM_ATTRIBUTE_DEFINITIONS_REGISTRATION = [
+    StandardAttribute("REG_SRC", ogr.OFTString, 20, 0),
+    StandardAttribute("DX", ogr.OFTReal, 0, 0),
+    StandardAttribute("DY", ogr.OFTReal, 0, 0),
+    StandardAttribute("DZ", ogr.OFTReal, 0, 0),
+    StandardAttribute("NUM_GCPS", ogr.OFTInteger, 8, 8),
+    StandardAttribute("MEANRESZ", ogr.OFTReal, 0, 0),
+]
+
+DEM_ATTRIBUTE_DEFINITIONS_MASKING = [
     StandardAttribute("REG_SRC", ogr.OFTString, 20, 0),
     StandardAttribute("DX", ogr.OFTReal, 0, 0),
     StandardAttribute("DY", ogr.OFTReal, 0, 0),
@@ -105,6 +118,7 @@ DEM_ATTRIBUTE_DEFINITIONS = DEM_ATTRIBUTE_DEFINITIONS_BASIC + [
     StandardAttribute("FILESZ_DEM", ogr.OFTReal, 0, 0),
     StandardAttribute("FILESZ_MT", ogr.OFTReal, 0, 0),
     StandardAttribute("FILESZ_OR", ogr.OFTReal, 0, 0),
+    StandardAttribute("FILESZ_OR2", ogr.OFTReal, 0, 0),
     StandardAttribute("INDEX_DATE", ogr.OFTString, 32, 0),
 ]
 
@@ -136,6 +150,8 @@ SCENE_ATTRIBUTE_DEFINITIONS_BASIC = [
     StandardAttribute("HAS_NONLSF", ogr.OFTInteger, 8, 8),
 ]
 
+SCENE_ATTRIBUTE_DEFINITIONS_REGISTRATION = []
+
 SCENE_ATTRIBUTE_DEFINITIONS = SCENE_ATTRIBUTE_DEFINITIONS_BASIC + [
     StandardAttribute("LOCATION", ogr.OFTString, 512, 0),
     StandardAttribute("FILESZ_DEM", ogr.OFTReal, 0, 0),
@@ -157,6 +173,9 @@ TILE_DEM_ATTRIBUTE_DEFINITIONS_BASIC = [
     StandardAttribute("REL_VER", ogr.OFTString, 32, 0),
     StandardAttribute("DENSITY", ogr.OFTReal, 0, 0),
     StandardAttribute("NUM_COMP", ogr.OFTInteger, 8, 8),
+]
+
+TILE_DEM_ATTRIBUTE_DEFINITIONS_REGISTRATION = [
     StandardAttribute("REG_SRC", ogr.OFTString, 20, 0),
     StandardAttribute("NUM_GCPS", ogr.OFTInteger, 8, 8),
     StandardAttribute("MEANRESZ", ogr.OFTReal, 0, 0),

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -148,6 +148,8 @@ SCENE_ATTRIBUTE_DEFINITIONS_BASIC = [
     StandardAttribute("ALGM_VER", ogr.OFTString, 32, 0),
     StandardAttribute("HAS_LSF", ogr.OFTInteger, 8, 8),
     StandardAttribute("HAS_NONLSF", ogr.OFTInteger, 8, 8),
+    StandardAttribute("IS_XTRACK", ogr.OFTInteger, 8, 8),
+    StandardAttribute("IS_DSP", ogr.OFTInteger, 8, 8),
 ]
 
 SCENE_ATTRIBUTE_DEFINITIONS_REGISTRATION = []

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -93,8 +93,8 @@ DEM_ATTRIBUTE_DEFINITIONS_BASIC = [
     StandardAttribute("IS_LSF", ogr.OFTInteger, 8, 8),
     StandardAttribute("IS_XTRACK", ogr.OFTInteger, 8, 8),
     StandardAttribute("EDGEMASK", ogr.OFTInteger, 8, 8),
-    StandardAttribute("CLOUDMASK", ogr.OFTInteger, 8, 8),
     StandardAttribute("WATERMASK", ogr.OFTInteger, 8, 8),
+    StandardAttribute("CLOUDMASK", ogr.OFTInteger, 8, 8),
     StandardAttribute("DENSITY", ogr.OFTReal, 0, 0),
 ]
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -142,6 +142,7 @@ SCENE_ATTRIBUTE_DEFINITIONS = SCENE_ATTRIBUTE_DEFINITIONS_BASIC + [
     StandardAttribute("FILESZ_LSF", ogr.OFTReal, 0, 0),
     StandardAttribute("FILESZ_MT", ogr.OFTReal, 0, 0),
     StandardAttribute("FILESZ_OR", ogr.OFTReal, 0, 0),
+    StandardAttribute("FILESZ_OR2", ogr.OFTReal, 0, 0),
     StandardAttribute("INDEX_DATE", ogr.OFTString, 32, 0),
 ]
 
@@ -224,7 +225,7 @@ class SpatialRef(object):
         try:
             epsgcode = int(epsg)
 
-        except ValueError, e:
+        except ValueError as e:
             raise RuntimeError("EPSG value must be an integer: %s" %epsg)
         else:
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -92,6 +92,9 @@ DEM_ATTRIBUTE_DEFINITIONS_BASIC = [
     StandardAttribute("ALGM_VER", ogr.OFTString, 32, 0),
     StandardAttribute("IS_LSF", ogr.OFTInteger, 8, 8),
     StandardAttribute("IS_XTRACK", ogr.OFTInteger, 8, 8),
+    StandardAttribute("EDGEMASK", ogr.OFTInteger, 8, 8),
+    StandardAttribute("CLOUDMASK", ogr.OFTInteger, 8, 8),
+    StandardAttribute("WATERMASK", ogr.OFTInteger, 8, 8),
     StandardAttribute("DENSITY", ogr.OFTReal, 0, 0),
 ]
 

--- a/package_setsm.py
+++ b/package_setsm.py
@@ -387,9 +387,6 @@ def build_archive(src,scratch,args):
                                     feat.SetField("DEM_RES",res)
                                     feat.SetField("DENSITY",raster.density)
                                     
-                                    if raster.version:
-                                        feat.SetField("REL_VER",raster.version)
-                                    
                                     #### Set fields if populated (will not be populated if metadata file is not found)
                                     if raster.creation_date:
                                         feat.SetField("CR_DATE",raster.creation_date.strftime("%Y-%m-%d"))


### PR DESCRIPTION
Indexer changes: 
1) Optional GCP fields for strips and tiles
2) Index 2m Dsp as 2m DEM
3) Index 2m Dsp as 50cm DEM substitute with info50cm txt files with aux info
4) Add file size for ortho2 for scenes and strips
5) Added is_xtrack, stripdemid, edgemask, matermask, cloudmask fields in strips
6) Added is_xtrack, is_dsp fields in scenes
7) Option to search for masked DEM strips
8) Custom status option
9) Doubled length of location field is all types, added field length check for setting fields