### PR TITLE
Option to verify indexer wrote required records to target layer

### DIFF
--- a/apply_setsm_registration.py
+++ b/apply_setsm_registration.py
@@ -128,7 +128,7 @@ def main():
         if args.pbs:
             try:
                 task_handler = taskhandler.PBSTaskHandler(qsubpath)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             else:
                 if not args.dryrun:
@@ -137,7 +137,7 @@ def main():
         elif args.slurm:
             try:
                 task_handler = taskhandler.SLURMTaskHandler(qsubpath)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             else:
                 if not args.dryrun:
@@ -146,7 +146,7 @@ def main():
         elif args.parallel_processes > 1:
             try:
                 task_handler = taskhandler.ParallelTaskHandler(args.parallel_processes)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error(e)
             else:
                 logger.info("Number of child processes to spawn: {0}".format(task_handler.num_processes))
@@ -270,7 +270,7 @@ def apply_reg(srcfp, args):
     for f in files_to_remove:
         try:
             os.remove(f)
-        except OSError, e:
+        except OSError as e:
             logger.info('Cannot remove {}'.format(f))
     
 if __name__ == '__main__':

--- a/calc_density.py
+++ b/calc_density.py
@@ -88,7 +88,7 @@ def main():
         logger.debug(src)
         try:
             raster = dem.SetsmDem(src)
-        except RuntimeError, e:
+        except RuntimeError as e:
             logger.error( e )
         else:
             j+=1
@@ -102,7 +102,7 @@ def main():
             
             try:
                 raster = dem.SetsmDem(sceneid)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error( e )
             else:
                 j+=1
@@ -117,7 +117,7 @@ def main():
                     logger.debug(srcfp)
                     try:
                         raster = dem.SetsmDem(srcfp)
-                    except RuntimeError, e:
+                    except RuntimeError as e:
                         logger.error( e )
                     else:
                         j+=1
@@ -214,14 +214,14 @@ def build_archive(src,scratch,args):
     
     try:
         raster.get_dem_info()
-    except RuntimeError, e:
+    except RuntimeError as e:
         logger.error(e)
     else:
         ## get raster density if not precomputed
         if raster.density is None:
             try:
                 raster.compute_density_and_statistics()
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.warning(e)
                 
 

--- a/calc_density_tiles.py
+++ b/calc_density_tiles.py
@@ -88,7 +88,7 @@ def main():
         logger.debug(src)
         try:
             raster = dem.SetsmTile(src)
-        except RuntimeError, e:
+        except RuntimeError as e:
             logger.error( e )
         else:
             j+=1
@@ -102,7 +102,7 @@ def main():
             
             try:
                 raster = dem.SetsmTile(sceneid)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error( e )
             else:
                 j+=1
@@ -117,7 +117,7 @@ def main():
                     logger.debug(srcfp)
                     try:
                         raster = dem.SetsmTile(srcfp)
-                    except RuntimeError, e:
+                    except RuntimeError as e:
                         logger.error( e )
                     else:
                         j+=1
@@ -214,14 +214,14 @@ def build_archive(src,scratch,args):
     
     try:
         raster.get_dem_info()
-    except RuntimeError, e:
+    except RuntimeError as e:
         logger.error(e)
     else:
         ## get raster density if not precomputed
         if raster.density is None:
             try:
                 raster.compute_density_and_statistics()
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.warning(e)
                 
 

--- a/copy_dems.py
+++ b/copy_dems.py
@@ -53,7 +53,7 @@ def main():
         parser.error("Src is not a valid directory or shapefile: %s" %src)
 
 
-    print "Collecting DEMs from source..."
+    print("Collecting DEMs from source...")
 
     #### ID all dems, pairname is dirname
     overlaps = []
@@ -85,19 +85,19 @@ def main():
                 try:
                     i = feat.GetFieldIndex(dem_fld)
                     dem_name = feat.GetField(i)
-                except ValueError, e:
-                    print "Cannot locate DEM name field (%s)" %(dem_fld)
+                except ValueError as e:
+                    print("Cannot locate DEM name field (%s)" %(dem_fld))
 
                 if not dem_name:
-                    print "Cannot locate DEM name field (%s)" %(dem_fld)
+                    print("Cannot locate DEM name field (%s)" %(dem_fld))
                 else:
 
                     for fld in flds:
                         try:
                             i = feat.GetFieldIndex(fld)
                             attrib = feat.GetField(i)
-                        except ValueError, e:
-                            print "Cannot locate candidate field (%s) in source feature class" %(fld)
+                        except ValueError as e:
+                            print("Cannot locate candidate field (%s) in source feature class" %(fld))
                         else:
                             if attrib:
                                 attrib_path = os.path.join(attrib,dem_name)
@@ -108,13 +108,13 @@ def main():
                                 elif os.path.isfile(attrib_path):
                                     path = attrib_path
                     if path:
-                        print path
+                        print(path)
                         overlaps.append(path)
                     else:
                         if len(paths) > 0:
-                            print "Cannot locate path for DEM in any of the following locations: \n%s" %('\n\t'.join(paths))
+                            print("Cannot locate path for DEM in any of the following locations: \n%s" %('\n\t'.join(paths)))
                         else:
-                            print "Cannot get valid values from candidate fields (%s) in source feature class" %(', '.join(flds))
+                            print("Cannot get valid values from candidate fields (%s) in source feature class" %(', '.join(flds)))
             ds = None
 
     overlaps = list(set(overlaps))
@@ -124,11 +124,11 @@ def main():
     i = 0
     for overlap in overlaps:
         i+=1
-        print '\n[%d of %d]\t %s' %(i,total,os.path.basename(overlap))
+        print('\n[%d of %d]\t %s' %(i,total,os.path.basename(overlap)))
 
         #### Check that path is not terranova storage location
         if args.move is True and (path.startswith(r'V:\pgc\data\elev\dem') or path.startswith(r'V:/pgc/data/elev/dem') or path.startswith(r'/mnt/pgc/data/elev/dem/asp')):
-            print "Cannot use --move flag on DEMs located in /pgc/data/elev/dem/"
+            print("Cannot use --move flag on DEMs located in /pgc/data/elev/dem/")
         else:
             srcpairdir = os.path.dirname(overlap)
             pairname = os.path.basename(srcpairdir)
@@ -157,13 +157,13 @@ def main():
                     ofp = os.path.join(file_dstdir,f)
                     if args.move is True:
                         if not os.path.isfile(ofp):
-                            print "Moving %s --> %s" %(ifp,ofp)
+                            print("Moving %s --> %s" %(ifp,ofp))
                             if not args.dryrun:
                                 os.rename(ifp,ofp)
 
                     else:
                         if not os.path.isfile(ofp):
-                            print "Copying %s --> %s" %(ifp,ofp)
+                            print("Copying %s --> %s" %(ifp,ofp))
                             if not args.dryrun:
                                 shutil.copy2(ifp,ofp)
 

--- a/divide_setsm_tiles.py
+++ b/divide_setsm_tiles.py
@@ -102,7 +102,7 @@ def main():
         logger.info(src)
         try:
             raster = dem.SetsmTile(src)
-        except RuntimeError, e:
+        except RuntimeError as e:
             logger.error( e )
         else:
             if src.endswith('reg_dem.tif'):
@@ -145,7 +145,7 @@ def main():
                         srcfp = os.path.join(root,f)
                         try:
                             raster = dem.SetsmTile(srcfp)
-                        except RuntimeError, e:
+                        except RuntimeError as e:
                             logger.error( e )
                         else:
                             if srcfp.endswith('reg_dem.tif'):
@@ -326,7 +326,7 @@ def divide_tile(src, args):
                         ds = gdal.Open(dstfp)
                         try:
                             stats = ds.GetRasterBand(1).GetStatistics(True,True)
-                        except RuntimeError, e:
+                        except RuntimeError as e:
                             logger.info("subtile has no data pixels, removing: {}".format(dstfp))
                             os.remove(dstfp)
                         else:

--- a/generate_browse_setsm.py
+++ b/generate_browse_setsm.py
@@ -188,7 +188,7 @@ def resample_setsm(dem, args):
                     try:
                         os.remove(f)
                     except:
-                        print "Cannot remove %s" %f
+                        print("Cannot remove %s" %f)
     
 def get_extension(image_format):
     if image_format == 'GTiff':

--- a/index_setsm.py
+++ b/index_setsm.py
@@ -782,6 +782,9 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
                                 finally:
                                     gdal.PopErrorHandler()
 
+            if invalid_record_cnt > 0:
+                logger.info("{} invalid records skipped".format(invalid_record_cnt))
+
             if len(recordids) == 0:
                 logger.error("No valid records found")
                 sys.exit(-1)

--- a/index_setsm.py
+++ b/index_setsm.py
@@ -439,7 +439,7 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
         if layer:
             # Get field widths
             lyr_def = layer.GetLayerDefn()
-            fwidths = {lyr_def.GetFieldDefn(i).GetName(): lyr_def.GetFieldDefn(i).GetWidth() for i in range(lyr_def.GetFieldCount())}
+            fwidths = {lyr_def.GetFieldDefn(i).GetName().upper(): lyr_def.GetFieldDefn(i).GetWidth() for i in range(lyr_def.GetFieldCount())}
 
             logger.info("Appending records...")
             #### loop through records and add features
@@ -706,10 +706,14 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
                         ## Write feature
                         if valid_record:
                             for fld,val in attrib_map.items():
-                                if isinstance(val, str) and len(val) > fwidths[fld]:
-                                    logger.warning("Attribute value {} is too long for field {} (width={}). Feature skipped".format(
-                                        val, fld, fwidths[fld]
-                                    ))
+                                if fld in fwidths:
+                                    if isinstance(val, str) and len(val) > fwidths[fld]:
+                                        logger.warning("Attribute value {} is too long for field {} (width={}). Feature skipped".format(
+                                            val, fld, fwidths[fld]
+                                        ))
+                                        valid_record = False
+                                else:
+                                    logger.warning("Field {} is not in target table. Feature skipped".format(fld))
                                     valid_record = False
                                 feat.SetField(  # force unicode to str for a bug in GDAL's SetField. Revisit in Python3
                                     fld.encode('utf-8'),

--- a/index_setsm.py
+++ b/index_setsm.py
@@ -70,6 +70,12 @@ recordid_map = {
 BP_PATH_PREFIX = 'https://blackpearl-data2.pgc.umn.edu/dems/setsm'
 TNVA_PATH_PREFIX = '/mnt/pgc/data/elev/dem/setsm'
 
+# handle unicode in Python 3
+try:
+    unicode('')
+except NameError:
+    unicode = str
+
 
 def main():
 

--- a/index_setsm.py
+++ b/index_setsm.py
@@ -63,6 +63,7 @@ MODES = {
 BP_PATH_PREFIX = 'https://blackpearl-data2.pgc.umn.edu/dems/setsm'
 TNVA_PATH_PREFIX = '/mnt/pgc/data/elev/dem/setsm'
 
+
 def main():
 
     #### Set Up Arguments
@@ -969,7 +970,6 @@ def decode_json(d):
         srs.ImportFromWkt(d['value'])
         return srs
     return d
-
 
 
 if __name__ == '__main__':

--- a/lib/dem.py
+++ b/lib/dem.py
@@ -91,7 +91,8 @@ asp_strip_pattern = re.compile("""(?P<pairname>
                                   (?P<catid2>[A-Z0-9]{16}))_?
                                   (?P<res>\d+m)?-dem.(tif|jpg)\Z""", re.I | re.X)
 
-setsm_tile_pattern = re.compile("""(?P<tile>\d+_\d+)_
+setsm_tile_pattern = re.compile("""((?P<scheme>utm\d{2}[ns])_)?
+                                   (?P<tile>\d+_\d+)_
                                    ((?P<subtile>\d+_\d+)_)?
                                    (?P<res>(\d+|0\.\d+)c?m)_
                                    ((?P<version>v[\d/.]+)_)?

--- a/lib/dem.py
+++ b/lib/dem.py
@@ -343,7 +343,11 @@ class SetsmScene(object):
                 raise RuntimeError("Dsp info file has incorrect number of values ({}/7)".format(len(self.dspmetad)))
             for k in self.filesz_attrib_map:
                 k2 = "dsp_{}".format(k)
-                setattr(self,k2,dspmetad[k])
+                try:
+                    val = float(dspmetad[k])
+                except ValueError as e:
+                    val = dspmetad[k]
+                setattr(self,k2,val)
         else:
             for k in self.filesz_attrib_map:
                 k2 = "dsp_{}".format(k)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -93,8 +93,8 @@ DEM_ATTRIBUTE_DEFINITIONS_BASIC = [
     StandardAttribute("IS_LSF", ogr.OFTInteger, 8, 8),
     StandardAttribute("IS_XTRACK", ogr.OFTInteger, 8, 8),
     StandardAttribute("EDGEMASK", ogr.OFTInteger, 8, 8),
-    StandardAttribute("CLOUDMASK", ogr.OFTInteger, 8, 8),
     StandardAttribute("WATERMASK", ogr.OFTInteger, 8, 8),
+    StandardAttribute("CLOUDMASK", ogr.OFTInteger, 8, 8),
     StandardAttribute("DENSITY", ogr.OFTReal, 0, 0),
 ]
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -265,7 +265,7 @@ class SpatialRef(object):
                 }
 
                 for pattern, replacement in proj4_patterns.iteritems():
-                    if proj4_string.find(pattern) <> -1:
+                    if proj4_string.find(pattern) != -1:
                         proj4_string = proj4_string.replace(pattern,replacement)
 
                 self.srs = srs

--- a/package_setsm.py
+++ b/package_setsm.py
@@ -103,7 +103,7 @@ def main():
         logger.debug(src)
         try:
             raster = dem.SetsmDem(src)
-        except RuntimeError, e:
+        except RuntimeError as e:
             logger.error( e )
         else:
             j+=1
@@ -122,7 +122,7 @@ def main():
             
             try:
                 raster = dem.SetsmDem(sceneid)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error( e )
             else:
                 j+=1
@@ -142,7 +142,7 @@ def main():
                     logger.debug(srcfp)
                     try:
                         raster = dem.SetsmDem(srcfp)
-                    except RuntimeError, e:
+                    except RuntimeError as e:
                         logger.error( e )
                     else:
                         j+=1
@@ -248,7 +248,7 @@ def build_archive(src,scratch,args):
     
     try:
         raster.get_dem_info()
-    except RuntimeError, e:
+    except RuntimeError as e:
         logger.error(e)
     else:
         process = True
@@ -257,7 +257,7 @@ def build_archive(src,scratch,args):
         if raster.density is None:
             try:
                 raster.compute_density_and_statistics()
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.warning(e)
         
         if args.filter_dems or args.force_filter_dems:
@@ -288,7 +288,7 @@ def build_archive(src,scratch,args):
                 try:
                     if not args.dryrun:
                         raster.write_mdf_file(args.lsf)
-                except RuntimeError, e:
+                except RuntimeError as e:
                     logger.error(e)
             
             #### Build Readme
@@ -307,7 +307,7 @@ def build_archive(src,scratch,args):
                         try:
                             os.remove(dstfp)
                         except:
-                            print "Cannot replace archive: %s" %srcfp
+                            print("Cannot replace archive: %s" %srcfp)
             
                 if not os.path.isfile(dstfp):    
                 
@@ -347,7 +347,7 @@ def build_archive(src,scratch,args):
                         ## create dem index shp: <strip_id>_index.shp
                         try:
                             index_dir, index_lyr = utils.get_source_names(index)
-                        except RuntimeError, e:
+                        except RuntimeError as e:
                             logger.error("{}: {}".format(index,e))            
                         
                         if os.path.isfile(index):
@@ -462,7 +462,7 @@ def build_archive(src,scratch,args):
                                         if not args.dryrun:
                                             try:
                                                 archive.close()
-                                            except Exception,e:
+                                            except Exception as e:
                                                 print e
                                                         
                                                         

--- a/package_setsm.py
+++ b/package_setsm.py
@@ -307,7 +307,7 @@ def build_archive(src,scratch,args):
                         try:
                             os.remove(dstfp)
                         except:
-                            print("Cannot replace archive: %s" %srcfp)
+                            print("Cannot replace archive: %s" %dstfp)
             
                 if not os.path.isfile(dstfp):    
                 
@@ -463,7 +463,7 @@ def build_archive(src,scratch,args):
                                             try:
                                                 archive.close()
                                             except Exception as e:
-                                                print e
+                                                print(e)
                                                         
                                                         
                                 else:

--- a/package_setsm_tiles.py
+++ b/package_setsm_tiles.py
@@ -101,7 +101,7 @@ def main():
         logger.debug(src)
         try:
             raster = dem.SetsmTile(os.path.join(src))
-        except RuntimeError, e:
+        except RuntimeError as e:
             logger.error( e )
         else:
             if not os.path.isfile(raster.archive) or args.overwrite:
@@ -115,7 +115,7 @@ def main():
                     logger.debug(os.path.join(root,f))
                     try:
                         raster = dem.SetsmTile(os.path.join(root,f))
-                    except RuntimeError, e:
+                    except RuntimeError as e:
                         logger.error( e )
                     else:
                         if not os.path.isfile(raster.archive) or args.overwrite:
@@ -175,16 +175,16 @@ def build_archive(raster,scratch,args):
 
     try:
         raster.get_dem_info()
-    except RuntimeError, e:
+    except RuntimeError as e:
         logger.error(e)
-        print raster.ndv
+        print(raster.ndv)
     else:
 
         ## get raster density if not precomputed
         if raster.density is None:
             try:
                 raster.compute_density_and_statistics()
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.warning(e)
 
         #### Build Archive
@@ -230,7 +230,7 @@ def build_archive(raster,scratch,args):
                 ## create dem index shp: <strip_id>_index.shp
                 try:
                     index_dir, index_lyr = utils.get_source_names(index)
-                except RuntimeError, e:
+                except RuntimeError as e:
                     logger.error("{}: {}".format(index,e))
 
                 if os.path.isfile(index):
@@ -341,8 +341,8 @@ def build_archive(raster,scratch,args):
                                 if not args.dryrun:
                                     try:
                                         archive.close()
-                                    except Exception,e:
-                                        print e
+                                    except Exception as e:
+                                        print(e)
 
                         else:
                             logger.error('Cannot create layer: {}'.format(dst_lyr))

--- a/package_setsm_tiles.py
+++ b/package_setsm_tiles.py
@@ -193,7 +193,7 @@ def build_archive(raster,scratch,args):
                 try:
                     os.remove(dstfp)
                 except:
-                    print "Cannot replace archive: %s" %srcfp
+                    print("Cannot replace archive: %s" %dstfp)
 
         if not os.path.isfile(dstfp):
 
@@ -345,7 +345,7 @@ def build_archive(raster,scratch,args):
                                         print(e)
 
                         else:
-                            logger.error('Cannot create layer: {}'.format(dst_lyr))
+                            logger.error('Cannot create layer: {}'.format(index_lyr))
                     else:
                         logger.error("Cannot create index: {}".format(index))
                 else:

--- a/rename_setsm_add_version.py
+++ b/rename_setsm_add_version.py
@@ -36,7 +36,7 @@ def main():
         logger.debug(src)
         try:
             raster = dem.SetsmDem(os.path.join(src))
-        except RuntimeError, e:
+        except RuntimeError as e:
             logger.error( e )
         else:
             rasters.append(raster)
@@ -48,7 +48,7 @@ def main():
                     #logger.info(os.path.join(root, f))
                     try:
                         raster = dem.SetsmDem(os.path.join(root, f))
-                    except RuntimeError, e:
+                    except RuntimeError as e:
                         logger.error( e )
                     else:
                         rasters.append(raster)
@@ -78,7 +78,7 @@ def rename(raster, args):
         ofn = "SETSM_{}_{}{}".format(fn[:len(raster.stripid)], args.version, fn[len(raster.stripid):])
         ofp = os.path.join(dirp, ofn)
         if os.path.isfile(ofp):
-            print "Output file already exists: {}".format(ofp)
+            print("Output file already exists: {}".format(ofp))
         else:
             logger.debug("{} --> {}".format(ifp, ofp))
             if not args.dryrun:

--- a/resample_setsm_tiles.py
+++ b/resample_setsm_tiles.py
@@ -72,7 +72,7 @@ def main():
             dem = path
             low_res_dem = "{}.tif".format(os.path.splitext(dem)[0])
             low_res_dem = os.path.join(os.path.dirname(low_res_dem),os.path.basename(low_res_dem.replace("_2m","_{}m".format(args.resolution))))
-            if dem <> low_res_dem and not os.path.isfile(low_res_dem):
+            if dem != low_res_dem and not os.path.isfile(low_res_dem):
                 i+=1
                 task = taskhandler.Task(
                     os.path.basename(dem),
@@ -91,7 +91,7 @@ def main():
                     dem = os.path.join(root,f)
                     low_res_dem = "{}.tif".format(os.path.splitext(dem)[0])
                     low_res_dem = os.path.join(os.path.dirname(low_res_dem),os.path.basename(low_res_dem.replace("_2m","_{}m".format(args.resolution))))
-                    if dem <> low_res_dem and not os.path.isfile(low_res_dem):
+                    if dem != low_res_dem and not os.path.isfile(low_res_dem):
                         i+=1
                         task = taskhandler.Task(
                             f,

--- a/shelve_setsm_by_date.py
+++ b/shelve_setsm_by_date.py
@@ -68,7 +68,7 @@ def main():
         logger.info(src)
         try:
             raster = dem.SetsmDem(src)
-        except RuntimeError, e:
+        except RuntimeError as e:
             logger.error( e )
         else:
             if raster.metapath is not None:
@@ -84,7 +84,7 @@ def main():
                     logger.debug(os.path.join(root,f))
                     try:
                         raster = dem.SetsmDem(os.path.join(root,f))
-                    except RuntimeError, e:
+                    except RuntimeError as e:
                         logger.error( e )
                     else:
                         if raster.metapath is not None:

--- a/shelve_setsm_by_geocell.py
+++ b/shelve_setsm_by_geocell.py
@@ -70,7 +70,7 @@ def main():
         logger.info(src)
         try:
             raster = dem.SetsmDem(src)
-        except RuntimeError, e:
+        except RuntimeError as e:
             logger.error( e )
         else:
             if raster.metapath is not None:
@@ -89,7 +89,7 @@ def main():
                     logger.debug(os.path.join(root,f))
                     try:
                         raster = dem.SetsmDem(os.path.join(root,f))
-                    except RuntimeError, e:
+                    except RuntimeError as e:
                         logger.error( e )
                     else:
                         if raster.metapath is not None:
@@ -129,7 +129,7 @@ def main():
                     if args.try_link:
                         try:
                             os.link(ifp,ofp)
-                        except OSError, e:
+                        except OSError:
                             logger.error("os.link failed on {}".format(ifp))
                     else:
                         shutil.copy2(ifp,ofp)
@@ -140,7 +140,7 @@ def main():
                     if args.try_link:
                         try:
                             os.link(ifp,ofp)
-                        except OSError, e:
+                        except OSError:
                             logger.error("os.link failed on {}".format(ifp))
                     else:
                         shutil.copy2(ifp,ofp)

--- a/shelve_setsm_by_shp.py
+++ b/shelve_setsm_by_shp.py
@@ -104,7 +104,7 @@ def main():
             logger.info(src)
             try:
                 raster = dem.SetsmDem(src)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 logger.error( e )
             else:
                 if raster.metapath or os.path.isfile(raster.mdf):
@@ -119,7 +119,7 @@ def main():
                         logger.debug(os.path.join(root,f))
                         try:
                             raster = dem.SetsmDem(os.path.join(root,f))
-                        except RuntimeError, e:
+                        except RuntimeError as e:
                             logger.error( e )
                         else:
                             if raster.metapath or os.path.isfile(raster.mdf):

--- a/tests/func_test_index.py
+++ b/tests/func_test_index.py
@@ -488,23 +488,24 @@ class TestIndexerIO(unittest.TestCase):
 
         test_param_list = (
             # input, output, args, result feature count, message
-            (os.path.join(self.tile_dir,'v3','33_11'), self.test_str, '', 3, 'Done'),  # test 100x100km tile at 3 resolutions
-            (os.path.join(self.tile_dir,'v3','33_11_quartertiles'), self.test_str, '--overwrite', 4, 'Done'), # test quartertiles formatted for release
-            (os.path.join(self.tile_dir,'v4','59_57'), self.test_str, '--overwrite', 4, 'Done'),  # test v4 tiles, 2m
+            (os.path.join(self.tile_dir,'v3','33_11'), self.test_str, '--project arcticdem', 3, 'Done'),  # test 100x100km tile at 3 resolutions
+            (os.path.join(self.tile_dir,'v3','33_11_quartertiles'), self.test_str, '--overwrite --project arcticdem', 4, 'Done'), # test quartertiles formatted for release
+            (os.path.join(self.tile_dir,'v4','59_57'), self.test_str, '--overwrite --project arcticdem', 4, 'Done'),  # test v4 tiles, 2m
+            (os.path.join(self.tile_dir, 'v4', 'utm34n_60_06'), self.test_str, '--overwrite --project earthdem', 4, 'Done'),  # test v4 utm tiles, 2m
         )
 
         for i, o, options, result_cnt, msg in test_param_list:
-            cmd = 'python index_setsm.py --mode tile --project arcticdem {} {} {}'.format(
+            cmd = 'python index_setsm.py --mode tile  {} {} {}'.format(
                 i,
                 o,
                 options
             )
             p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             (so,se) = p.communicate()
-            #print(se)
-            #print(so)
+            print(se)
+            print(so)
 
-            ## Test if ds exists and has corrent number of records
+            ## Test if ds exists and has correct number of records
             self.assertTrue(os.path.isfile(o))
             ds = ogr.Open(o,0)
             layer = ds.GetLayer()
@@ -513,7 +514,7 @@ class TestIndexerIO(unittest.TestCase):
             self.assertEqual(cnt,result_cnt)
             ds, layer = None, None
 
-            ##Test if stdout has proper error
+            ## Test if stdout has proper error
             self.assertIn(msg,se)
 
     def testTileJson(self):

--- a/tests/func_test_index.py
+++ b/tests/func_test_index.py
@@ -49,7 +49,7 @@ class TestIndexerIO(unittest.TestCase):
             (self.scene_dir, self.test_str, '', self.scene_count, 'Done'),  # test creation
             (self.scene_dir, self.test_str, '--append', self.scene_count * 2, 'Done'),  # test append
             (self.scene_dir, self.test_str, '', self.scene_count * 2, 'Dst shapefile exists.  Use the --overwrite or --append options.'), # test error meeasge on existing
-            (self.scene_dir, self.test_str, '--overwrite', self.scene_count, 'Removing old index'), # test overwrite
+            (self.scene_dir, self.test_str, '--overwrite --check', self.scene_count, 'Removing old index'), # test overwrite
         )
 
         for i, o, options, result_cnt, msg in test_param_list:
@@ -89,7 +89,7 @@ class TestIndexerIO(unittest.TestCase):
             (self.scene_dir, self.test_str, '', self.scene_count, 'Done'),  # test creation
             (self.scene_dir, self.test_str, '--append', self.scene_count * 2 , 'Done'),  # test append
             (self.scene_dir, self.test_str, '', self.scene_count * 2, 'Dst GDB layer exists.  Use the --overwrite or --append options.'), # test error meeasge on existing
-            (self.scene_dir, self.test_str, '--overwrite', self.scene_count, 'Removing old index'), # test overwrite
+            (self.scene_dir, self.test_str, '--overwrite --check', self.scene_count, 'Removing old index'), # test overwrite
         )
 
         for i, o, options, result_cnt, msg in test_param_list:
@@ -141,7 +141,7 @@ class TestIndexerIO(unittest.TestCase):
             (self.scene_dir, self.pg_test_str, '', self.scene_count, 'Done', 2),  # test creation
             (self.scene_dir, self.pg_test_str, '--append', self.scene_count * 2, 'Done', 2),  # test append
             (self.scene_dir, self.pg_test_str, '', self.scene_count * 2, 'Dst DB layer exists.  Use the --overwrite or --append options.', 2), # test error meeasge on existing
-            (self.scene_dir, self.pg_test_str, '--overwrite', self.scene_count, 'Removing old index', 2), # test overwrite
+            (self.scene_dir, self.pg_test_str, '--overwrite --check', self.scene_count, 'Removing old index', 2), # test overwrite
             (self.scenedsp_dir, self.pg_test_str, '--overwrite', self.scenedsp_count, 'Done', 2),  # test as 2m_dsp record
             (self.scenedsp_dir, self.pg_test_str, '--overwrite --dsp-original-res', self.scenedsp_count, 'Done', 0.5),
         )
@@ -233,7 +233,7 @@ class TestIndexerIO(unittest.TestCase):
         test_param_list = (
             # input, output, args, result feature count, message
             (self.scenedsp_dir, self.test_str, '', self.scenedsp_count, 'Done', 2),  # test as 2m_dsp record
-            (self.scenedsp_dir, self.test_str, '--overwrite --dsp-original-res', self.scenedsp_count, 'Done', 0.5),  # test as 50cm record
+            (self.scenedsp_dir, self.test_str, '--overwrite --dsp-original-res --check', self.scenedsp_count, 'Done', 0.5),  # test as 50cm record
         # test as 50cm record
         )
 
@@ -332,7 +332,7 @@ class TestIndexerIO(unittest.TestCase):
 
         ## Test json read
         test_shp = os.path.join(self.output_dir,'test.shp')
-        cmd = 'python index_setsm.py {} {} --skip-region-lookup --read-json'.format(
+        cmd = 'python index_setsm.py {} {} --skip-region-lookup --read-json --check'.format(
             self.output_dir,
             test_shp,
         )
@@ -402,7 +402,7 @@ class TestIndexerIO(unittest.TestCase):
         test_param_list = (
             # input, output, args, result feature count, message
             (self.strip_dir, self.test_str, '', self.strip_count, 'Done'),  # test creation
-            (self.stripmasked_dir, self.test_str, '--overwrite', self.stripmasked_count, 'Done'),  # test index of masked strips
+            (self.stripmasked_dir, self.test_str, '--overwrite --check', self.stripmasked_count, 'Done'),  # test index of masked strips
             (self.stripmasked_dir, self.test_str, '--overwrite --search-masked', self.stripmasked_count * 5, 'Done'),  # test index of masked strips
         )
 
@@ -490,7 +490,7 @@ class TestIndexerIO(unittest.TestCase):
             # input, output, args, result feature count, message
             (os.path.join(self.tile_dir,'v3','33_11'), self.test_str, '--project arcticdem', 3, 'Done'),  # test 100x100km tile at 3 resolutions
             (os.path.join(self.tile_dir,'v3','33_11_quartertiles'), self.test_str, '--overwrite --project arcticdem', 4, 'Done'), # test quartertiles formatted for release
-            (os.path.join(self.tile_dir,'v4','59_57'), self.test_str, '--overwrite --project arcticdem', 4, 'Done'),  # test v4 tiles, 2m
+            (os.path.join(self.tile_dir,'v4','59_57'), self.test_str, '--overwrite --check --project arcticdem', 4, 'Done'),  # test v4 tiles, 2m
             (os.path.join(self.tile_dir, 'v4', 'utm34n_60_06'), self.test_str, '--overwrite --project earthdem', 4, 'Done'),  # test v4 utm tiles, 2m
         )
 


### PR DESCRIPTION
I added a --check option for the indexer that verifies the presence of the required records in the target layer after writing them by building a key made up of three components:

- DEM ID (scenedemid and stripdemid, dem_id and stripdemid, or dem_id and tile depending on the mode)
- LOCATION
- INDEX_DATE
 
It is technically possible to have a false positive, but not likely given the way we use this tool. This option was built to handle instances where records are not written to postgres, but no error is thrown.  Perhaps it can help simplify Danny's ingest checks as well.