### PR TITLE
Properly read scaled int LERC_ZSTD compressed dems

### DIFF
--- a/lib/dem.py
+++ b/lib/dem.py
@@ -647,7 +647,7 @@ class SetsmDem(object):
                 matchtag_res_x = gtf[1]
                 matchtag_res_y = gtf[5]
                 matchtag_ndv = b.GetNoDataValue()
-                data = b.ReadAsArray()
+                data = utils.gdalReadAsArraySetsmSceneBand(b)
                 err = gdal.GetLastErrorNo()
                 if err != 0:
                     raise RuntimeError("Matchtag dataset read error: {}, {}".format(gdal.GetLastErrorMsg(),self.srcfp))
@@ -1526,7 +1526,7 @@ class SetsmTile(object):
             res_x = gtf[1]
             res_y = gtf[5]
             ndv = b.GetNoDataValue()
-            data = b.ReadAsArray()
+            data = utils.gdalReadAsArraySetsmSceneBand(b)
             err = gdal.GetLastErrorNo()
             if err != 0:
                 raise RuntimeError("DEM dataset read error: {}, {}".format(gdal.GetLastErrorMsg(),self.srcfp))

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -5,15 +5,9 @@ demtools utilties and constants
 """
 
 from collections import namedtuple
-import glob
 import logging
-import multiprocessing as mp
 import os
 import re
-import shutil
-import string
-import subprocess
-import sys
 
 from osgeo import gdal, osr, ogr, gdalconst
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 
+import numpy as np
 from osgeo import gdal, osr, ogr, gdalconst
 
 #### Create Logger
@@ -244,6 +245,11 @@ def osr_srs_preserve_axis_order(osr_srs):
     return osr_srs
 
 
+class RasterIOError(Exception):
+    def __init__(self, msg=""):
+        super(Exception, self).__init__(msg)
+
+
 class SpatialRef(object):
 
     def __init__(self,epsg):
@@ -378,3 +384,46 @@ def drange(start, stop, step):
     while r < stop:
         yield r
         r += step
+
+
+def gdalReadAsArraySetsmSceneBand(raster_band, make_nodata_nan=False):
+    scale = raster_band.GetScale()
+    offset = raster_band.GetOffset()
+    if scale is None:
+        scale = 1.0
+    if offset is None:
+        offset = 0.0
+    if scale == 1.0 and offset == 0.0:
+        array_data = raster_band.ReadAsArray()
+        if make_nodata_nan:
+            nodata_val = raster_band.GetNoDataValue()
+            if nodata_val is not None:
+                array_data[array_data == nodata_val] = np.nan
+    else:
+        if raster_band.DataType != gdalconst.GDT_Int32:
+            raise RasterIOError(
+                "Expected GDAL raster band with scale!=1.0 or offset!=0.0 to be of Int32 data type"
+                " (scaled int LERC_ZSTD-compressed 50cm DEM), but data type is {}".format(
+                    gdal.GetDataTypeName(raster_band.DataType)
+                )
+            )
+        if scale == 0.0:
+            raise RasterIOError(
+                "GDAL raster band has invalid parameters: scale={}, offset={}".format(scale, offset)
+            )
+        nodata_val = raster_band.GetNoDataValue()
+        array_data = raster_band.ReadAsArray(buf_type=gdalconst.GDT_Float32)
+        adjust_where = (array_data != nodata_val) if nodata_val is not None else True
+        if scale != 1.0:
+            np.multiply(array_data, scale, out=array_data, where=adjust_where)
+        if offset != 0.0:
+            np.add(array_data, offset, out=array_data, where=adjust_where)
+        if make_nodata_nan:
+            array_nodata = np.logical_not(adjust_where, out=adjust_where)
+            array_data[array_nodata] = np.nan
+        del adjust_where
+
+    if array_data is None:
+        raise RasterIOError("`raster_band.ReadAsArray()` returned None")
+
+    return array_data

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -4,10 +4,18 @@
 demtools utilties and constants
 """
 
-import os, sys, string, shutil, glob, re, logging, subprocess
-from osgeo import gdal, osr, ogr, gdalconst
 from collections import namedtuple
+import glob
+import logging
 import multiprocessing as mp
+import os
+import re
+import shutil
+import string
+import subprocess
+import sys
+
+from osgeo import gdal, osr, ogr, gdalconst
 
 #### Create Logger
 logger = logging.getLogger("logger")


### PR DESCRIPTION
Last week I pushed the scenes2strips code as far as I could in post-processing 50cm DEMs on Nunatak. I actually got a working Conda environment using Jim's GDAL build with the LERC codec & FileGDB, that could also play with OpenCV!!!

In the process, I noticed that GDAL was not automatically converting the scaled int 50cm DEM rasters when read into python using the normal process:
```
ds = gdal.Open("file")
band = ds.GetRasterBand(1)
dem_data = band.ReadAsArray()
```
The `dem_data` array you get from is in Int32 data type with the scaling still applied (scale factor = 100x original elev values).

After some back and forth with Jim, I wrote up the function `gdalReadAsArraySetsmSceneBand()` to be added to `utils.py` in this PR. **It's very important** that we use this function whenever doing post-processing work on SETSM dems when there's even a slight possibility that the code could be working on scaled int LERC_ZSTD-compressed 50cm dems. If we don't handle the data type conversion with proper NoData handling, things could go really badly without much notice to the user.