### PR TITLE
Correct strip JSON filenames, couple other tweaks

### DIFF
--- a/index_setsm.py
+++ b/index_setsm.py
@@ -31,6 +31,12 @@ handler=err.handler # Note don't pass class method directly or python segfaults
 gdal.PushErrorHandler(handler)
 gdal.UseExceptions() #Exceptions will get raised on anything >= gdal.CE_Failure
 
+# Script paths and execution
+SCRIPT_FILE = os.path.abspath(os.path.realpath(__file__))
+SCRIPT_FNAME = os.path.basename(SCRIPT_FILE)
+SCRIPT_NAME, SCRIPT_EXT = os.path.splitext(SCRIPT_FNAME)
+SCRIPT_DIR = os.path.dirname(SCRIPT_FILE)
+
 #### Create Logger
 logger = logging.getLogger("logger")
 logger.setLevel(logging.DEBUG)
@@ -115,7 +121,7 @@ def main():
     #### Optional Arguments
     parser.add_argument('--mode', choices=MODES.keys(), default='scene',
                         help="type of items to index {} default=scene".format(MODES.keys()))
-    parser.add_argument('--config', default=os.path.join(os.path.dirname(sys.argv[0]),'config.ini'),
+    parser.add_argument('--config', default=os.path.join(SCRIPT_DIR, 'config.ini'),
                         help="config file (default is config.ini in script dir")
     parser.add_argument('--epsg', type=int, default=4326,
                         help="egsg code for output index projection (default wgs85 geographic epsg:4326)")

--- a/index_setsm.py
+++ b/index_setsm.py
@@ -999,7 +999,8 @@ def write_to_json(json_fd, groups, total, args):
 
             for item in items:
                 i+=1
-                progress(i,total,"records written")
+                if not args.np:
+                    progress(i,total,"records written")
 
                 # organize scene obj into dict and write to json
                 md[item.id] = item.__dict__

--- a/index_setsm.py
+++ b/index_setsm.py
@@ -410,8 +410,9 @@ def main():
         logger.info("{} records found".format(total))
         ## Group into strips or tiles for json writing
         groups = {}
+        json_groupid_fld = 'stripdirname' if args.mode == 'strip' else groupid_fld
         for record in records:
-            groupid = getattr(record,groupid_fld)
+            groupid = getattr(record, json_groupid_fld)
             if groupid in groups:
                 groups[groupid].append(record)
             else:

--- a/lib/dem.py
+++ b/lib/dem.py
@@ -475,6 +475,7 @@ class SetsmDem(object):
             self.srcdir, self.srcfn = os.path.split(self.srcfp)
             self.stripid = self.srcfn[:self.srcfn.find('_dem')]
             self.stripdemid = None
+            self.stripdirname = None
             self.id = self.stripid
             if 'lsf' in self.srcfn:
                 self.is_lsf = True
@@ -643,6 +644,11 @@ class SetsmDem(object):
 
             ## Make strip ID
             self.stripdemid = '_'.join((self.pairname, self.res_str, version_str))
+            self.stripdirname = '_'.join((
+                self.pairname,
+                "{}{}".format(self.res_str, '_lsf' if self.is_lsf else ''),
+                version_str
+            ))
 
     def compute_density_and_statistics(self):
         #### If no mdf or mdf does not contain valid density key, compute


### PR DESCRIPTION
When using the index_setsm.py `--write-json` option to verify strips (`--mode='strips'`), we want the JSON files written next to the strip folders. Problem is that the JSON filenames were being created based on the DEM's `stripdemid` attribute, which doesn't include the "_lsf" part of the strip folder names. So I made an adjustment to use a new DEM attribute called `stripdirname`, which includes the "_lsf" part, if applicable.

Added a couple other convenience tweaks to index_setsm.py as well.