### PR TITLE
Update Packaging and Strip Metadata

### DIFF
--- a/calc_density.py
+++ b/calc_density.py
@@ -115,7 +115,8 @@ def main():
         except RuntimeError as e:
             logger.error(e)
         else:
-            if raster.density is None:
+            needed_attribs = (raster.density, raster.masked_density, raster.max_elev_value, raster.min_elev_value)
+            if any([a is None for a in needed_attribs]):
                 scenes.append(srcfp)
 
     logger.info('Number of incomplete tasks: {}'.format(len(scenes)))
@@ -197,18 +198,22 @@ def main():
         logger.info("No tasks found to process")
 
 
-def build_archive(src,scratch,args):
+def build_archive(src, scratch, args):
 
     logger.info("Calculating density of raster: {}".format(src))
     raster = dem.SetsmDem(src)
     raster.get_metafile_info()
 
-    if raster.density is None:
+    needed_attribs = (raster.density, raster.masked_density, raster.max_elev_value, raster.min_elev_value)
+    if any([a is None for a in needed_attribs]):
         try:
             raster.compute_density_and_statistics()
         except RuntimeError as e:
             logger.warning(e)
-                
+
+    needed_attribs = (raster.density, raster.masked_density, raster.max_elev_value, raster.min_elev_value)
+    if any([a is None for a in needed_attribs]):
+        logger.warning("Density or stats calculation failed")
 
 if __name__ == '__main__':
     main()

--- a/index_setsm.py
+++ b/index_setsm.py
@@ -670,10 +670,9 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
 
                             if record.version and 'REL_VER' in fld_list:
                                 attrib_map['REL_VER'] = record.version
-                            if record.density:
-                                attrib_map['DENSITY'] = record.density
-                            else:
-                                attrib_map['DENSITY'] = -9999
+
+                            attrib_map['DENSITY'] = record.density if record.density else -9999
+                            attrib_map['MASK_DENS'] = record.masked_density if record.masked_density else -9999
 
                             ## If registration info exists
                             if args.include_registration:
@@ -770,10 +769,8 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
                                 version = record.version
                             else:
                                 version = 'novers'
-                            if record.density:
-                                attrib_map['DENSITY'] = record.density
-                            else:
-                                attrib_map['DENSITY'] = -9999
+
+                            attrib_map['DENSITY'] = record.density if record.density else -9999
 
                             if args.include_registration:
                                 if record.reg_src:

--- a/lib/dem.py
+++ b/lib/dem.py
@@ -124,6 +124,9 @@ class SetsmScene(object):
         ## If md dictionary is passed in, recreate object from dict instead of from file location
         if md:
             self._rebuild_scene_from_dict(md)
+            ## Check if epsg is valid and recalculate if not - catch effects of a jsons build with a bug
+            if not self.epsg:
+                self.epsg = get_epsg(self.proj4)
 
         else:
             self.srcdir, self.srcfn = os.path.split(metapath)
@@ -237,16 +240,11 @@ class SetsmScene(object):
             src_srs.ImportFromWkt(self.proj)
             self.srs = src_srs
             self.proj4 = src_srs.ExportToProj4()
-            self.epsg = ''
 
-            for epsg in epsgs:
-                tgt_srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference())
-                tgt_srs.ImportFromEPSG(epsg)
-                if src_srs.IsSame(tgt_srs) == 1:
-                    self.epsg = epsg
-                    break
-            if self.epsg == '':
-                raise RuntimeError("No EPSG match for DEM proj4 '{}': {}".format(self.proj4, dsp))
+            try:
+                self.epsg = get_epsg(src_srs)
+            except RuntimeError as e:
+                raise RuntimeError(e)
 
             src_srs.MorphToESRI()
             self.wkt_esri = src_srs.ExportToWkt()
@@ -472,6 +470,9 @@ class SetsmDem(object):
         ## If md dictionary is passed in, recreate object from dict instead of from file location
         if md:
             self._rebuild_scene_from_dict(md)
+            ## Check if epsg is valid and recalculate if not - catch effects of a jsons build with a bug
+            if not self.epsg:
+                self.epsg = get_epsg(self.proj4)
 
         else:
             self.srcfp = filepath
@@ -595,16 +596,11 @@ class SetsmDem(object):
             src_srs.ImportFromWkt(self.proj)
             self.srs = src_srs
             self.proj4 = src_srs.ExportToProj4()
-            self.epsg = ''
 
-            for epsg in epsgs:
-                tgt_srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference())
-                tgt_srs.ImportFromEPSG(epsg)
-                if src_srs.IsSame(tgt_srs) == 1:
-                    self.epsg = epsg
-                    break
-            if self.epsg == '':
-                raise RuntimeError("No EPSG match for DEM proj4 '{}': {}".format(self.proj4, self.srcfp))
+            try:
+                self.epsg = get_epsg(src_srs)
+            except RuntimeError as e:
+                raise RuntimeError(e)
 
             src_srs.MorphToESRI()
             self.wkt_esri = src_srs.ExportToWkt()
@@ -1349,18 +1345,10 @@ class AspDem(object):
             src_srs.ImportFromWkt(self.proj)
             self.proj4 = src_srs.ExportToProj4()
             #print self.proj4
-            self.epsg = ''
-
-            for epsg in epsgs:
-                tgt_srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference())
-                tgt_srs.ImportFromEPSG(epsg)
-                #print epsg
-                #print src_srs.IsSame(tgt_srs)
-                if src_srs.IsSame(tgt_srs) == 1:
-                    self.epsg = epsg
-                    break
-            if self.epsg == '':
-                raise RuntimeError("No EPSG match for DEM proj4 '{}': {}".format(self.proj4, self.srcfp))
+            try:
+                self.epsg = get_epsg(src_srs)
+            except RuntimeError as e:
+                raise RuntimeError(e)
 
             src_srs.MorphToESRI()
             self.wkt_esri = src_srs.ExportToWkt()
@@ -1572,18 +1560,10 @@ class SetsmTile(object):
             self.srs = src_srs
             self.proj4 = src_srs.ExportToProj4()
             #print self.proj4
-            self.epsg = ''
-
-            for epsg in epsgs:
-                tgt_srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference())
-                tgt_srs.ImportFromEPSG(epsg)
-                #print epsg
-                #print src_srs.IsSame(tgt_srs)
-                if src_srs.IsSame(tgt_srs) == 1:
-                    self.epsg = epsg
-                    break
-            if self.epsg == '':
-                raise RuntimeError("No EPSG match for DEM proj4 '{}': {}".format(self.proj4, self.srcfp))
+            try:
+                self.epsg = get_epsg(src_srs)
+            except RuntimeError as e:
+                raise RuntimeError(e)
 
             src_srs.MorphToESRI()
             self.wkt_esri = src_srs.ExportToWkt()
@@ -1875,3 +1855,35 @@ def get_raster_density(raster_fp, geom_area=None, bitmask_fp=None):
             density = data_pixel_count / float(total_pixel_count)
 
         return density
+
+def get_epsg(src_srs):
+    '''
+    Returns epsg code
+    Input: osr spatial reference or proj4 string
+    Output: EPSG code (int)
+    '''
+
+    valid_srs = True
+    if isinstance(src_srs, str):
+        srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference())
+        srs.ImportFromProj4(src_srs)
+    elif isinstance(src_srs, osr.SpatialReference):
+        srs = src_srs
+    else:
+        valid_srs = False
+
+    if not valid_srs:
+        raise RuntimeError("Input is not a osr.SpatialReference object or proj4 string")
+
+    raster_epsg = None
+    for epsg in epsgs:
+        tgt_srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference())
+        tgt_srs.ImportFromEPSG(epsg)
+        if srs.IsSame(tgt_srs) == 1:
+            raster_epsg = epsg
+            break
+    if not raster_epsg:
+        raise RuntimeError("No EPSG match for DEM proj4 '{}': {}".format(self.proj4, self.srcfp))
+
+    return raster_epsg
+

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -224,6 +224,7 @@ DEM_ATTRIBUTE_DEFINITIONS_BASIC = [
     StandardAttribute("WATERMASK", ogr.OFTInteger, 8, 8),
     StandardAttribute("CLOUDMASK", ogr.OFTInteger, 8, 8),
     StandardAttribute("DENSITY", ogr.OFTReal, 0, 0),
+    StandardAttribute("MASK_DENS", ogr.OFTReal, 0, 0),
     StandardAttribute("RMSE", ogr.OFTReal, 0, 0),
 ]
 

--- a/package_setsm.py
+++ b/package_setsm.py
@@ -13,7 +13,7 @@ tgt_srs = osr.SpatialReference()
 tgt_srs.ImportFromEPSG(4326)
 
 AREA_THRESHOLD = 5500000  # Filter threshold in sq meters
-DENSITY_THRESHOLD = 0.1   # Masked matchtag density threshold
+DENSITY_THRESHOLD = 0.2   # Masked matchtag density threshold
 
 
 def main():

--- a/package_setsm_tiles.py
+++ b/package_setsm_tiles.py
@@ -268,8 +268,8 @@ def build_archive(raster,scratch,args):
                             feat.SetField("DENSITY",raster.density)
                             feat.SetField("NUM_COMP",raster.num_components)
 
-                            if raster.version:
-                                feat.SetField("REL_VER",raster.version)
+                            if raster.release_version:
+                                feat.SetField("REL_VER",raster.release_version)
 
                             if raster.reg_src:
                                 feat.SetField("REG_SRC",raster.reg_src)

--- a/qsub_package.sh
+++ b/qsub_package.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-#PBS -l walltime=40:00:00,nodes=1:ppn=4,mem=16gb
+#PBS -l walltime=40:00:00,nodes=1:ppn=4,mem=32gb
 #PBS -m n
 #PBS -k oe
 #PBS -j oe
+#PBS -q new
 
 cd $PBS_O_WORKDIR
 

--- a/tests/func_test_index.py
+++ b/tests/func_test_index.py
@@ -657,10 +657,10 @@ class TestIndexerIO(unittest.TestCase):
             (self.strip_dir, self.test_str, '--read-pickle {}/tests/testdata/pair_region_lookup.p --custom-paths BP'.format(root_dir),
              self.strip_count, 'Done'),  # test BP paths
             (self.strip_dir, self.test_str,
-             '--read-pickle tests/testdata/pair_region_lookup.p --overwrite --custom-paths PGC',
+             '--read-pickle {}/tests/testdata/pair_region_lookup.p --overwrite --custom-paths PGC'.format(root_dir),
              self.strip_count, 'Done'),  # test PGC paths
             (self.strip_dir, self.test_str,
-             '--read-pickle tests/testdata/pair_region_lookup.p --skip-region-lookup --overwrite --custom-paths CSS',
+             '--read-pickle {}/tests/testdata/pair_region_lookup.p --skip-region-lookup --overwrite --custom-paths CSS'.format(root_dir),
              self.strip_count,
              'Done'),  # test CSS paths
         )
@@ -674,6 +674,7 @@ class TestIndexerIO(unittest.TestCase):
             )
             p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             (so, se) = p.communicate()
+            # print(cmd)
             # print(se)
             # print(so)
 

--- a/tests/func_test_index.py
+++ b/tests/func_test_index.py
@@ -37,6 +37,7 @@ class TestIndexerIO(unittest.TestCase):
         self.scene50cm_dir = os.path.join(testdata_dir, 'setsm_scene_50cm')
         self.scenedsp_dir = os.path.join(testdata_dir, 'setsm_scene_2mdsp')
         self.strip_dir = os.path.join(testdata_dir, 'setsm_strip')
+        self.strip_mixedver_dir = os.path.join(testdata_dir, 'setsm_strip_mixedver')
         self.stripmasked_dir = os.path.join(testdata_dir, 'setsm_strip_masked')
         self.tile_dir = os.path.join(testdata_dir, 'setsm_tile')
         self.output_dir = os.path.join(testdata_dir, 'output')
@@ -48,6 +49,7 @@ class TestIndexerIO(unittest.TestCase):
         self.scenedsp_count = 102
         self.strip_count = 4
         self.stripmasked_count = 3
+        self.strip_mixedver_count = 4
 
     def tearDown(self):
         ## Clean up output
@@ -550,6 +552,7 @@ class TestIndexerIO(unittest.TestCase):
         test_param_list = (
             # input, output, args, result feature count, message
             (self.strip_dir, self.test_str, '', self.strip_count, 'Done'),  # test creation
+            (self.strip_mixedver_dir, self.test_str, '--overwrite', self.strip_mixedver_count, 'Done'),  # test mixed version
             (self.stripmasked_dir, self.test_str, '--overwrite --check', self.stripmasked_count, 'Done'), # test index of masked strips
             (self.stripmasked_dir, self.test_str, '--overwrite --search-masked', self.stripmasked_count * 5, 'Done'),  # test index of masked strips
         )
@@ -572,6 +575,7 @@ class TestIndexerIO(unittest.TestCase):
             )
             p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             (so, se) = p.communicate()
+            # print(cmd)
             # print(se)
             # print(so)
 
@@ -583,7 +587,10 @@ class TestIndexerIO(unittest.TestCase):
             cnt = layer.GetFeatureCount()
             self.assertEqual(cnt, result_cnt)
             for feat in layer:
-                srcfn = os.path.basename(feat.GetField('LOCATION'))
+                srcfp = feat.GetField('LOCATION')
+                srcdir, srcfn = os.path.split(srcfp)
+                stripdemid = feat.GetField('STRIPDEMID')
+                self.assertEqual(os.path.basename(srcdir).replace('_lsf',''),stripdemid)
                 dem_suffix = srcfn[srcfn.find('_dem'):]
                 masks = strip_masks[dem_suffix]
                 self.assertEqual(feat.GetField('EDGEMASK'), masks[0])


### PR DESCRIPTION
- Introduced the masked density concept and rolled it out in  package_setsm and index_setsm.
- Added better handling of density, masked density, min and max elevation values in dem.py
- Updated index_setsm to handle unset EPSG codes in pre-built jsons.
- Added a flag making it optional to skip original resolution DSP records when no original file size info was found.
- Added check for Strip DEM ID in strip dem metadata to report version and derive custom file location correctly.
- Updated code around removing strips with low data density in the package_setsm code and raised the threshold to 0.2.
