### PR TITLE
Couple fixes for strip indexing from JSONs

### DIFF
--- a/index_setsm.py
+++ b/index_setsm.py
@@ -648,8 +648,8 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
                                 'SENSOR2': record.sensor2,
                                 'ACQDATE1': record.acqdate1.strftime('%Y-%m-%d'),
                                 'ACQDATE2': record.acqdate2.strftime('%Y-%m-%d'),
-                                'AVGACQTM1': record.avg_acqtime1.strftime("%Y-%m-%d %H:%M:%S") if record.avg_acqtime1 else None,
-                                'AVGACQTM2': record.avg_acqtime2.strftime("%Y-%m-%d %H:%M:%S") if record.avg_acqtime2 else None,
+                                'AVGACQTM1': record.avg_acqtime1.strftime("%Y-%m-%d %H:%M:%S") if record.avg_acqtime1 is not None else None,
+                                'AVGACQTM2': record.avg_acqtime2.strftime("%Y-%m-%d %H:%M:%S") if record.avg_acqtime2 is not None else None,
                                 'CATALOGID1': record.catid1,
                                 'CATALOGID2': record.catid2,
                                 'IS_LSF': int(record.is_lsf),
@@ -680,8 +680,8 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
                             if record.release_version and 'REL_VER' in fld_list:
                                 attrib_map['REL_VER'] = record.release_version
 
-                            attrib_map['DENSITY'] = record.density if record.density else -9999
-                            attrib_map['MASK_DENS'] = record.masked_density if record.masked_density else -9999
+                            attrib_map['DENSITY'] = record.density if record.density is not None else -9999
+                            attrib_map['MASK_DENS'] = record.masked_density if record.masked_density is not None else -9999
 
                             ## If registration info exists
                             if args.include_registration:
@@ -779,7 +779,7 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
                             else:
                                 version = 'novers'
 
-                            attrib_map['DENSITY'] = record.density if record.density else -9999
+                            attrib_map['DENSITY'] = record.density if record.density is not None else -9999
 
                             if args.include_registration:
                                 if record.reg_src:

--- a/lib/dem.py
+++ b/lib/dem.py
@@ -479,12 +479,15 @@ class SetsmDem(object):
                 self.release_version = md['version']
             if 'masked_density' not in md:
                 self.masked_density = -9999
+            if 'min_elev_value' not in md:
+                self.min_elev_value = None
+            if 'max_elev_value' not in md:
+                self.max_elev_value = None
             if 'avg_acqtime1' not in md:
                 self.set_acqtime_attribs()
             if 'rmse' not in md:
                 self.set_rmse_attrib()
-            elif self.rmse == -2:
-                self.rmse = -9999
+            self.set_density_and_stats_attribs()
 
         else:
             self.srcfp = filepath
@@ -886,25 +889,7 @@ class SetsmDem(object):
             raise RuntimeError("Neither meta.txt nor mdf.txt file exists for DEM")
 
         #### If density file exists, get density and stats from there
-        needed_attribs = (self.density, self.masked_density, self.max_elev_value, self.min_elev_value)
-        if any([a is None for a in needed_attribs]):
-            if os.path.isfile(self.density_file):
-                fh = open(self.density_file, 'r')
-                lines = fh.readlines()
-                stats_line = 1
-                try:
-                    self.density = float(lines[0].strip())
-                    if ',' not in lines[1]:
-                        stats_line = 2
-                        self.masked_density = float(lines[1].strip())
-                    stats = lines[stats_line].strip().split(',')
-                    self.min_elev_value = float(stats[0])
-                    self.max_elev_value = float(stats[1])
-                except IndexError:
-                    pass
-                except ValueError:
-                    pass
-                fh.close()
+        self.set_density_and_stats_attribs()
 
         #### If reg.txt file exists, parse it for registration info
         if len(self.reginfo_list) == 0:
@@ -982,6 +967,27 @@ class SetsmDem(object):
         if len(values) > 0:
             self.acqdate2 = values[0]
             self.avg_acqtime2 = datetime.fromtimestamp(sum([time.mktime(t.timetuple()) + t.microsecond / 1e6 for t in values]) / len(values))
+
+    def set_density_and_stats_attribs(self):
+        needed_attribs = (self.density, self.masked_density, self.max_elev_value, self.min_elev_value)
+        if any([a is None for a in needed_attribs]):
+            if os.path.isfile(self.density_file):
+                fh = open(self.density_file, 'r')
+                lines = fh.readlines()
+                stats_line = 1
+                try:
+                    self.density = float(lines[0].strip())
+                    if ',' not in lines[1]:
+                        stats_line = 2
+                        self.masked_density = float(lines[1].strip())
+                    stats = lines[stats_line].strip().split(',')
+                    self.min_elev_value = float(stats[0])
+                    self.max_elev_value = float(stats[1])
+                except IndexError:
+                    pass
+                except ValueError:
+                    pass
+                fh.close()
 
     def write_mdf_file(self):
 


### PR DESCRIPTION
- Enable overwriting of ('None') density values read from JSONs when (presumably newer) `density.txt` files exist.
- Bugfix where density values of 0 would be replaced with -9999 in target index.