### PR TITLE
COG package strips

### DIFF
--- a/lib/dem.py
+++ b/lib/dem.py
@@ -527,9 +527,10 @@ class SetsmDem(object):
             self.ortho2 = os.path.join(self.srcdir, self.stripid + "_ortho2.tif")
             self.mdf = os.path.join(self.srcdir,self.stripid+"_mdf.txt")
             self.readme = os.path.join(self.srcdir,self.stripid+"_readme.txt")
-            self.browse = os.path.join(self.srcdir,self.stripid+"_dem_browse.tif")
+            self.browse = os.path.join(self.srcdir, self.stripid + "_dem_10m_shade.tif")
+            self.browse_masked = os.path.join(self.srcdir, self.stripid + "_dem_10m_shade_masked.tif")
             if not os.path.isfile(self.browse):
-                self.browse = os.path.join(self.srcdir, self.stripid + "_dem_10m_shade.tif")
+                self.browse = os.path.join(self.srcdir,self.stripid+"_dem_browse.tif")
             self.density_file = os.path.join(self.srcdir,self.stripid+"_density.txt")
             self.bitmask = os.path.join(self.srcdir, self.stripid + "_bitmask.tif")
             self.reg_files = [

--- a/package_setsm.py
+++ b/package_setsm.py
@@ -25,7 +25,7 @@ def main():
         )
     
     #### Positional Arguments
-    parser.add_argument('src', help="source directory or dem")
+    parser.add_argument('src', help="source directory, text file of file paths, or dem")
     parser.add_argument('scratch', help="scratch space to build index shps")
     
     #### Optional Arguments
@@ -562,7 +562,7 @@ def wrap_180(src_geom):
         if (pt1[0] > 0) - (pt1[0] < 0) != (pt2[0] > 0) - (pt2[0] < 0):
 
             ## if segment crosses,calculate interesection point y value
-            pt3_y = calc_y_intersection_180(pt1, pt2)
+            pt3_y = utils.calc_y_intersection_180(pt1, pt2)
 
             ## add intersection point to both bins (make sureot change 180 to -180 for western list)
             pt3_west = ( -180, pt3_y )

--- a/package_setsm.py
+++ b/package_setsm.py
@@ -277,6 +277,7 @@ def build_archive(src,scratch,args):
                 os.path.basename(raster.mdf),  # mdf
                 os.path.basename(raster.readme),  # readme
                 os.path.basename(raster.browse),  # browse
+                os.path.basename(raster.browse_masked),  # browse with mask
                 os.path.basename(raster.bitmask),  # bitmask
                 # index shp files
             )

--- a/shelve_setsm_strips_simple.py
+++ b/shelve_setsm_strips_simple.py
@@ -1,15 +1,13 @@
-import os, sys, string, shutil, glob, re, logging, math
-from datetime import *
-from osgeo import gdal, osr, ogr, gdalconst
 import argparse
-from collections import namedtuple
-import numpy
-from numpy import flatnonzero
+import glob
+import logging
+import os
+from datetime import *
+
 from lib import utils, dem
 
 #### Create Logger
-logger = logging.getLogger("logger")
-logger.setLevel(logging.DEBUG)
+logger = utils.get_logger()
 
 
 MODES = (
@@ -19,15 +17,18 @@ MODES = (
 )
 DEFAULT_MODE = 'geocell'
 
+class RawTextArgumentDefaultsHelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter): pass
+
 def main():
     
     #### Set Up Arguments 
     parser = argparse.ArgumentParser(
+        formatter_class=RawTextArgumentDefaultsHelpFormatter,
         description="shelve setsm files by geocell"
         )
     
     #### Positional Arguments
-    parser.add_argument('src', help="source directory or dem")
+    parser.add_argument('src', help="source directory, text file (of file paths or dir paths), or dem")
     parser.add_argument('dst', help="destination directory")
     
     #### Optionsl Arguments
@@ -35,7 +36,7 @@ def main():
                         help='shelving folder structure')
     parser.add_argument('--shp', help='if mode = shp, provide a shapefile here of target tiling scheme')
     parser.add_argument('--field', help='if mode = shp, provide a field name for the folders in the --shp file')
-    parser.add_argument('--res', choices=['2m','8m'], help="only shelve DEMs of resolution <res> (2 or 8)")
+    parser.add_argument('--res', choices=['2m', '8m'], help="only shelve DEMs of resolution <res> (2 or 8)")
     parser.add_argument('--try-link', action='store_true', default=False,
                         help="try linking instead of copying files")
     parser.add_argument('--skip-ortho', action='store_true', default=False,
@@ -62,12 +63,6 @@ def main():
     
     src = os.path.abspath(args.src)
     dst = os.path.abspath(args.dst)
-
-    lsh = logging.StreamHandler()
-    lsh.setLevel(logging.INFO)
-    formatter = logging.Formatter('%(asctime)s %(levelname)s- %(message)s','%m-%d-%Y %H:%M:%S')
-    lsh.setFormatter(formatter)
-    logger.addHandler(lsh)
     
     if args.log:
         if os.path.isdir(args.log):
@@ -84,38 +79,10 @@ def main():
     
     rasters = []
 
-    ### Open shp, verify field, verify projetion, extract tile geoms
+    ### Open shp, verify field, verify projection, extract tile geoms
     proceed = True
     if args.mode == 'shp':
-
-        tiles = {}
-        shp = os.path.abspath(args.shp)
-        ds = ogr.Open(shp)
-        if ds is not None:
-
-            lyr = ds.GetLayerByName(os.path.splitext(os.path.basename(shp))[0])
-            lyr.ResetReading()
-
-            i = lyr.FindFieldIndex(args.field, 1)
-            if i == -1:
-                logger.error("Cannot locate field {} in {}".format(args.field, shp))
-                sys.exit(-1)
-
-            shp_srs = lyr.GetSpatialRef()
-            if shp_srs is None:
-                logger.error("Shp must have a defined spatial reference")
-                sys.exit(-1)
-
-            for feat in lyr:
-                tile_name = feat.GetFieldAsString(i)
-                tile_geom = feat.GetGeometryRef().Clone()
-                if not tile_name in tiles:
-                    tiles[tile_name] = tile_geom
-                else:
-                    logger.error("Found features with duplicate name: {} - Ignoring 2nd feature".format(tile_name))
-
-        else:
-            logger.error("Cannot open {}".format(src))
+        tiles, shp_srs = utils.get_tiles_from_shp(os.path.abspath(args.shp), args.field)
 
         if len(tiles) == 0:
             logger.error("No features found in shp")
@@ -125,14 +92,27 @@ def main():
         #### ID rasters
         srcfps = []
         logger.info('Identifying DEMs')
-        if os.path.isfile(src):
+        if os.path.isfile(src) and src.endswith('.tif'):
             logger.info(src)
             srcfps.append(src)
+
+        elif os.path.isfile(src) and src.endswith('.txt'):
+            fh = open(src, 'r')
+            for line in fh.readlines():
+                l = line.strip()
+                if os.path.isfile(l):
+                    srcfps.append(l)
+                elif os.path.isdir(l):
+                    srcfp_list = glob.glob(l + '/*dem.tif')
+                    srcfps.extend(srcfp_list)
+                else:
+                    logger.warning('Text file input line is not a file or folder: {}'.format(l))
+
         else:
-            for root,dirs,files in os.walk(src):
+            for root, dirs, files in os.walk(src):
                 for f in files:
                     if f.endswith("_dem.tif"):
-                        srcfp = os.path.join(root,f)
+                        srcfp = os.path.join(root, f)
                         logger.debug(srcfp)
                         srcfps.append(srcfp)
 
@@ -151,103 +131,19 @@ def main():
                 else:
                     logger.warning("DEM does not include a valid meta.txt and cannot be shelved: {}".format(raster.srcfp))
 
+        logger.info('{} DEMs found'.format(len(rasters)))
+
         logger.info('Shelving DEMs')
         total = len(rasters)
         i = 0
         for raster in rasters:
             #### print count/total as progress meter
             i+=1
-            #logger.info("[{} of {}] - {}".format(i,total,raster.stripid))
-            dst_dir = None
-            if args.mode == 'geocell':
-                ## get centroid and round down to floor to make geocell folder
-                raster.get_metafile_info()
-                geocell = raster.get_geocell()
-                dst_dir = os.path.join(dst, geocell)
-
-            elif args.mode == 'date':
-                platform = raster.sensor1
-                year = raster.acqdate1.strftime("%Y")
-                month = raster.acqdate1.strftime("%m")
-                day = raster.acqdate1.strftime("%d")
-                dst_dir = os.path.join(dst, platform, year, month, day)
-
-            elif args.mode == 'shp':
-                ## Convert geom to match shp srs and get centroid
-                raster.get_metafile_info()
-                geom_copy = raster.geom.Clone()
-                srs = utils.osr_srs_preserve_axis_order(osr.SpatialReference())
-                srs.ImportFromProj4(raster.proj4_meta)
-                if not shp_srs.IsSame(srs):
-                    ctf = osr.CoordinateTransformation(srs, shp_srs)
-                    geom_copy.Transform(ctf)
-                centroid = geom_copy.Centroid()
-
-                ## Run intersection with each tile
-                tile_overlaps = []
-                for tile_name, tile_geom in tiles.items():
-                    if centroid.Intersects(tile_geom):
-                        tile_overlaps.append(tile_name)
-
-                ## Raise an error on multiple intersections or zero intersections
-                if len(tile_overlaps) == 0:
-                    logger.warning("raster {} does not intersect the index shp, skipping".format(raster.srcfn))
-
-                elif len(tile_overlaps) > 1:
-                    logger.warning("raster {} intersects more than one tile ({}), skipping".format(raster.srcfn,
-                                                                                                 ','.join(tile_overlaps)))
-                else:
-                    #logger.info("{} shelved to tile {}".format(raster.stripid, tile_overlaps[0]))
-                    dst_dir = os.path.join(dst, tile_overlaps[0])
-
-            if dst_dir:
-                if not os.path.isdir(dst_dir):
-                    if not args.dryrun:
-                        os.makedirs(dst_dir)
-
-                glob1 = glob.glob(os.path.join(raster.srcdir, raster.stripid)+"_*")
-                tar_path = os.path.join(raster.srcdir, raster.stripid)+".tar.gz"
-                if os.path.isfile(tar_path):
-                    glob1.append(tar_path)
-
-                if args.skip_ortho:
-                    glob2 = [f for f in glob1 if 'ortho' not in f]
-                    glob1 = glob2
-
-                ## Check if existing and remove all matching files if overwrite
-                glob3 = glob.glob(os.path.join(dst_dir, raster.stripid) + "_*")
-                tar_path = os.path.join(dst_dir, raster.stripid) + ".tar.gz"
-                if os.path.isfile(tar_path):
-                    glob3.append(tar_path)
-
-                proceed = True
-                if len(glob3) > 0:
-                    if args.overwrite:
-                        logger.info("Destination files already exist for {} - overwriting all dest files".format(
-                                raster.stripid))
-                        for ofp in glob3:
-                            logger.debug("Removing {} due to --overwrite flag".format(ofp))
-                            if not args.dryrun:
-                                os.remove(ofp)
-                    else:
-                        logger.info("Destination files already exist for {} - skipping DEM. Use --overwrite to overwrite".format(
-                            raster.stripid))
-                        proceed = False
-
-                ## Link or copy files
-                if proceed:
-                    for ifp in glob1:
-                        ofp = os.path.join(dst_dir, os.path.basename(ifp))
-                        logger.debug("Linking {} to {}".format(ifp, ofp))
-                        if not args.dryrun:
-                            if args.try_link:
-                                try:
-                                    os.link(ifp, ofp)
-                                except OSError:
-                                    logger.error("os.link failed on {}".format(ifp))
-                            else:
-                                logger.debug("Copying {} to {}".format(ifp, ofp))
-                                shutil.copy2(ifp, ofp)
+            logger.debug("[{} of {}] - {}".format(i,total,raster.stripid))
+            if args.mode == 'shp':
+                utils.shelve_item(raster, dst, args, tiles, shp_srs)
+            else:
+                utils.shelve_item(raster, dst, args)
 
         logger.info('Done')
 


### PR DESCRIPTION
This PR adds COG creation functionality to package_setsm.py.  COG compression is LZW with predictor=yes (2 to 3) for all files except the bitmasks and matchtags, which use predictor=no (1).  The packager also includes the 10m_shade_masked file in addition to the unmasked shade file. The shelve_setm_strip_simple.py script can now also take a text file of input dems instead of only a dir or file.