### PR TITLE
Bypass 50cminfo

### DIFF
--- a/index_setsm.py
+++ b/index_setsm.py
@@ -543,6 +543,12 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
                             for k in record.filesz_attrib_map:
                                 attrib_map[k.upper()] = getattr(record,'{}{}'.format(attr_pfx,k))
 
+                            # TODO revisit after  all incorrect 50cminfo.txt files are ingested
+                            # Overwrite original res dsp filesz values will Null
+                            if dsp_mode == 'orig':
+                                for k in record.filesz_attrib_map:
+                                    attrib_map[k.upper()] = None
+
                             # Test if filesz attr is valid for dsp original res records
                             if dsp_mode == 'orig':
                                 if attrib_map['FILESZ_DEM'] is None:

--- a/tests/func_test_index.py
+++ b/tests/func_test_index.py
@@ -390,17 +390,18 @@ class TestIndexerIO(unittest.TestCase):
                 scenedemid = feat.GetField('SCENEDEMID')
                 stripdemid = feat.GetField('STRIPDEMID')
                 location = feat.GetField('LOCATION')
+                record_res = feat.GetField('DEM_RES')
                 scenedemid_lastpart = scenedemid.split('_')[-1]
                 location_lastpart = location.split('_')[-2]
                 if '-' in location_lastpart:
                     self.assertEqual(scenedemid_lastpart.split('-')[1], location_lastpart.split('-')[1])
                 if res:
-                    self.assertEqual(feat.GetField('DEM_RES'), res)
+                    self.assertEqual(record_res, res)
                     self.assertTrue(scenedemid_lastpart.startswith('2' if res == 2.0 else '0'))
                     self.assertTrue(res_str[res] in stripdemid)
                     self.assertEqual(feat.GetField('IS_DSP'), 1 if res == 2.0 else 0)
-                self.assertTrue(scenedemid_lastpart.startswith('2' if feat.GetField('DEM_RES') == 2.0 else '0'))
-                self.assertEqual(feat.GetField('IS_DSP'), 1 if feat.GetField('DEM_RES') == 2.0 else 0)
+                self.assertTrue(scenedemid_lastpart.startswith('2' if record_res == 2.0 else '0'))
+                self.assertEqual(feat.GetField('IS_DSP'), 1 if record_res == 2.0 else 0)
                 if '--status-dsp-record-mode-orig aws' in options:
                     if '--custom-paths BP' in options:
                         self.assertEqual(feat.GetField('STATUS'), 'aws' if feat.GetField('DEM_RES') == 0.5 else 'tape')
@@ -408,7 +409,7 @@ class TestIndexerIO(unittest.TestCase):
                         self.assertEqual(feat.GetField('STATUS'), 'aws' if feat.GetField('DEM_RES') == 0.5 else 'online')
 
                 # TODO revert to all records using assertIsNotNone after all incorrect 50cminfo.txt files are ingested
-                if res == 0.5:
+                if record_res == 0.5:
                     self.assertIsNone(feat.GetField('FILESZ_DEM'))
                 else:
                     self.assertIsNotNone(feat.GetField('FILESZ_DEM'))

--- a/tests/func_test_index.py
+++ b/tests/func_test_index.py
@@ -407,6 +407,12 @@ class TestIndexerIO(unittest.TestCase):
                     else:
                         self.assertEqual(feat.GetField('STATUS'), 'aws' if feat.GetField('DEM_RES') == 0.5 else 'online')
 
+                # TODO revert to all records using assertIsNotNone after all incorrect 50cminfo.txt files are ingested
+                if res == 0.5:
+                    self.assertIsNone(feat.GetField('FILESZ_DEM'))
+                else:
+                    self.assertIsNotNone(feat.GetField('FILESZ_DEM'))
+
             ds, layer = None, None
 
             # Test if stdout has proper error
@@ -549,9 +555,15 @@ class TestIndexerIO(unittest.TestCase):
             self.assertEqual(feat.GetField('IS_DSP'), 1 if feat.GetField('DEM_RES') == 2.0 else 0)
             self.assertTrue(scenedemid_lastpart.startswith('2' if feat.GetField('DEM_RES') == 2.0 else '0'))
 
+            # TODO revert to all records using assertIsNotNone after all incorrect 50cminfo.txt files are ingested
+            if res == 0.5:
+                self.assertIsNone(feat.GetField('FILESZ_DEM'))
+            else:
+                self.assertIsNotNone(feat.GetField('FILESZ_DEM'))
+
             ds, layer = None, None
 
-    # # @unittest.skip("test")
+    # @unittest.skip("test")
     def testStrip(self):
 
         test_param_list = (


### PR DESCRIPTION
When using index_setsm.py to make 50cm records from a 2m_dsp DEM, bypass the 50cminfo.txt files and set the files size attributes to null.