### PR TITLE
Escape literal periods used in regex patterns

### DIFF
--- a/lib/dem.py
+++ b/lib/dem.py
@@ -64,7 +64,7 @@ setsm_scene_pattern = re.compile("""(?P<pairname>
                                     (?P<order2>\d{12}_\d{2}_P\d{3})_
                                     (?P<res>[0128])
                                     (-(?P<subtile>\d{2}))?
-                                    _meta.txt\Z""", re.I | re.X)
+                                    _meta\.txt\Z""", re.I | re.X)
 
 setsm_strip_pattern = re.compile("""((?P<algorithm>SETSM)_)?
                                     ((?P<relversion>s2s[\d/]+)_)?
@@ -77,9 +77,9 @@ setsm_strip_pattern = re.compile("""((?P<algorithm>SETSM)_)?
                                     (?P<res>(\d+|0\.\d+)c?m)_
                                     (lsf_)?
                                     (?P<partnum>SEG\d+)_
-                                    ((?P<relversion2>v[\d/.]+)_)?
+                                    ((?P<relversion2>v[\d\.]+)_)?
                                     (?P<suffix>dem(_water-masked|_cloud-masked|_cloud-water-masked|_masked)?
-                                    .(tif|jpg))\Z""", re.I | re.X)
+                                    \.(tif|jpg))\Z""", re.I | re.X)
 
 setsm_strip_pattern2 = re.compile("""(?P<pairname>
                                     (?P<sensor>[A-Z][A-Z\d]{2}\d)_
@@ -89,16 +89,16 @@ setsm_strip_pattern2 = re.compile("""(?P<pairname>
                                     )_
                                     (?P<partnum>SEG\d+)_
                                     (?P<res>(\d+|0\.\d+)c?m)_
-                                    ((?P<relversion>v[\d/.]+)_)?
+                                    ((?P<relversion>v[\d\.]+)_)?
                                     (lsf_)?
-                                    (?P<suffix>dem.(tif|jpg))\Z""", re.I | re.X)
+                                    (?P<suffix>dem\.(tif|jpg))\Z""", re.I | re.X)
 
 asp_strip_pattern = re.compile("""(?P<pairname>
                                   (?P<sensor>[A-Z]{2}\d{2})_
                                   (?P<timestamp>\d{8})_
                                   (?P<catid1>[A-Z0-9]{16})_
                                   (?P<catid2>[A-Z0-9]{16}))_?
-                                  (?P<res>\d+m)?-dem.(tif|jpg)\Z""", re.I | re.X)
+                                  (?P<res>\d+m)?-dem\.(tif|jpg)\Z""", re.I | re.X)
 
 setsm_tile_pattern = re.compile("""((?P<scheme>utm\d{2}[ns])_)?
                                    (?P<tile>\d+_\d+)_
@@ -106,7 +106,7 @@ setsm_tile_pattern = re.compile("""((?P<scheme>utm\d{2}[ns])_)?
                                    (?P<res>(\d+|0\.\d+)c?m)_
                                    ((?P<relversion>v[\d\.]+)_)?
                                    (reg_)?
-                                   dem.tif\Z""", re.I| re.X)
+                                   dem\.tif\Z""", re.I| re.X)
 
 xtrack_sensor_pattern = re.compile("[wqg]\d[wqg]\d", re.I)
 s2s_version_pattern = re.compile("Strip Metadata( \(v(?P<s2sversion>\d[\d\.]*)\))?")


### PR DESCRIPTION
I noticed that usage of an offshoot of one of these regex patterns in the shelve-setsm-dems repo was catching more source files than it was supposed to, because the period in the file extension part of the regex was not escaped.

@clairecporter I don't have any particular error cases that I've hit with index_setsm.py concerning this issue so far, but could run your standard tests for these regex fixes at some point?