### PR TITLE
Add `SetsmTile` attributes for mosaic tile STAC work

### DIFF
--- a/lib/dem.py
+++ b/lib/dem.py
@@ -511,13 +511,13 @@ class SetsmDem(object):
                 elif type(getattr(self, a)) is str:
                     setattr(self, a, float(getattr(self, a)))
             if 'avg_acqtime1' not in md:
-                self.set_acqtime_attribs()
+                self._set_acqtime_attribs()
             if 'rmse' not in md:
-                self.set_rmse_attrib()
+                self._set_rmse_attrib()
             if self.rmse == -2:
                 self.rmse = -9999
-            self.set_density_and_stats_attribs()
-            self.set_group_attribs_from_scenes()
+            self._set_density_and_stats_attribs()
+            self._set_group_attribs_from_scenes()
 
         else:
             self.srcfp = filepath
@@ -823,13 +823,13 @@ class SetsmDem(object):
                 self.algm_version_key = semver2verkey(group_version)
 
             ## get scene coregistration rmse
-            self.set_rmse_attrib()
+            self._set_rmse_attrib()
 
             ## get acqdates and acqtimes
-            self.set_acqtime_attribs()
+            self._set_acqtime_attribs()
 
             ## get averages from scene attribs
-            self.set_group_attribs_from_scenes()
+            self._set_group_attribs_from_scenes()
 
             ## get sensors
             values = []
@@ -973,7 +973,7 @@ class SetsmDem(object):
             raise RuntimeError("Neither meta.txt nor mdf.txt file exists for DEM: {}".format(self.srcfp))
 
         #### If density file exists, get density and stats from there
-        self.set_density_and_stats_attribs()
+        self._set_density_and_stats_attribs()
 
         #### If reg.txt file exists, parse it for registration info
         if len(self.reginfo_list) == 0:
@@ -996,7 +996,7 @@ class SetsmDem(object):
                     # logger.info("dz: {}, dx: {}, dy: {}".format(self.dz, self.dx, self.dy))
                     fh.close()
 
-    def set_group_attribs_from_scenes(self):
+    def _set_group_attribs_from_scenes(self):
         needed_attribs = (
             self.avg_conv_angle, self.avg_exp_height_acc,
             self.avg_sun_el1, self.avg_sun_el2
@@ -1025,7 +1025,7 @@ class SetsmDem(object):
             if len(sun_els2) > 0:
                 self.avg_sun_el2 = numpy.mean(numpy.array(sun_els2))
 
-    def set_rmse_attrib(self):
+    def _set_rmse_attrib(self):
         values = []
         for scene_name, align_stats in self.alignment_dct.items():
             scene_rmse = align_stats[0]
@@ -1038,7 +1038,7 @@ class SetsmDem(object):
         else:
             self.rmse = -1
 
-    def set_acqtime_attribs(self):
+    def _set_acqtime_attribs(self):
         values = []
         for x in range(len(self.scenes)):
             acqtime_str = None
@@ -1081,7 +1081,7 @@ class SetsmDem(object):
             self.acqdate2 = values[0]
             self.avg_acqtime2 = datetime.fromtimestamp(sum([time.mktime(t.timetuple()) + t.microsecond / 1e6 for t in values]) / len(values))
 
-    def set_density_and_stats_attribs(self):
+    def _set_density_and_stats_attribs(self):
         needed_attribs = (self.masked_density, self.max_elev_value, self.min_elev_value)
         if any([a is None for a in needed_attribs]):
             if os.path.isfile(self.density_file):

--- a/lib/dem.py
+++ b/lib/dem.py
@@ -1619,7 +1619,6 @@ class SetsmTile(object):
         ## If md dictionary is passed in, recreate object from dict instead of from file location
         if md:
             self._rebuild_scene_from_dict(md)
-            self._set_component_attribs()
 
         else:
             self.srcfp = srcfp
@@ -1944,6 +1943,7 @@ class SetsmTile(object):
         'ndv',
         'num_components',
         'ortho',
+        'pairname_ids',
         'proj',
         'proj4',
         'regmetapath',


### PR DESCRIPTION
These are the new `SetsmTile` attributes:
 - `pairname_ids`: list of stereo pairnames of strips that make up the mosaic tile data, to be mapped to STAC `pgc:pairname_ids[]` property
 - `acqdate_min`: earliest stereo pairname date, to be mapped to STAC `start_datetime` and `datetime` properties
 - `acqdate_max`: latest stereo pairname date, to be mapped to STAC `end_datetime` property

I tested creating JSONs for some of the REMA mosaic tiles, and it appears the new attributes are being created correctly.
Here's how the new attributes appear in the JSONs:
```
"pairname_ids": ["WV01_20121222_1020010020797E00_102001001E757700", "WV01_20150224_102001003756F300_102001003B7C9F00", "WV01_20150308_102001003853C900_1020010039025E00", "WV01_20150314_102001003E4FC900_102001003B90AD00", "WV01_20151103_1020010045907600_1020010046AD6600", "WV01_20151111_10200100453CAC00_10200100471DE400", "WV01_20170918_10200100687AFB00_1020010062687E00", "WV01_20170919_102001006748D900_1020010067A99E00", "WV02_20121214_103001001E24DB00_103001001E59E700", "WV02_20150415_103001004117DE00_1030010040923200", "WV02_20160909_103001005B5C8A00_103001005C542800", "WV02_20170306_10300100659A2600_10300100661B6000", "WV02_20170927_1030010072CD4E00_10300100718A3300", "WV02_20181129_1030010087249600_1030010089798E00", "WV03_20161016_10400100248DF100_10400100238C4D00", "WV03_20170306_1040010029802F00_104001002A113800", "WV03_20170313_104001002B543B00_104001002A35AA00", "WV03_20170926_10400100320D9900_104001003368DB00", "WV03_20180112_1040010036696100_104001003749EB00", "WV03_20180417_104001003B592C00_104001003998C700", "WV03_20180920_1040010042254A00_1040010041173E00", "WV03_20181028_1040010044217300_1040010044A95700", "WV03_20190110_1040010046673700_10400100468BA100"], "acqdate_min": {"__datetime__": true, "value": "datetime.datetime(2012, 12, 14, 0, 0)"}, "acqdate_max": {"__datetime__": true, "value": "datetime.datetime(2019, 1, 10, 0, 0)"}
```