### PR TITLE
Mosaic tile index fixes

### DIFF
--- a/lib/dem.py
+++ b/lib/dem.py
@@ -110,8 +110,11 @@ setsm_tile_pattern = re.compile("""((?P<scheme>utm\d{2}[ns])_)?
                                    (reg_)?
                                    dem\.tif\Z""", re.I| re.X)
 
-setsm_pairname_pattern = re.compile("""(?P<pairname>
-                                       (?P<sensor>[A-Z]{2}\d{2})_
+setsm_pairname_pattern = re.compile("""((?P<algorithm>SETSM)_
+                                       (?P<relversion>s2s\d{3})_
+                                       )?
+                                       (?P<pairname>
+                                       (?P<sensor>[A-Z][A-Z\d]{2}\d)_
                                        (?P<timestamp>\d{8})_
                                        (?P<catid1>[A-Z0-9]{16})_
                                        (?P<catid2>[A-Z0-9]{16}))""", re.I | re.X)
@@ -1873,7 +1876,7 @@ class SetsmTile(object):
                     scene_id = os.path.splitext(alignment_stats[0])[0]
                     alignment_dct[scene_id] = alignment_stats[1:]
 
-                elif l[:2] in ['WV','GE']:
+                elif l[:2] in ['WV','GE','W1','W2','W3','G1'] or l.startswith('SETSM_s2s'):
                     component_list.append(l)
 
         metad['alignment_dct'] = alignment_dct

--- a/lib/dem.py
+++ b/lib/dem.py
@@ -1828,6 +1828,8 @@ class SetsmTile(object):
 
         if 'Version' in metad:
             self.release_version = metad['Version']
+            if not self.release_version.startswith('v'):
+                self.release_version = 'v{}'.format(self.release_version)
 
         self.num_components = len(self.alignment_dct)
         if self.num_components == 0:

--- a/lib/dem.py
+++ b/lib/dem.py
@@ -1664,7 +1664,7 @@ class SetsmTile(object):
                 self.tilename = groups['tile']
                 self.res = groups['res']
                 # In case release version is in the file name and not the meta.txt
-                self.release_version = groups['relversion']
+                self.release_version = groups['relversion'].strip('v')
                 self.subtile = groups['subtile']
                 self.scheme = groups['scheme']
 
@@ -1827,9 +1827,7 @@ class SetsmTile(object):
             raise RuntimeError('Key "Creation Date" not found in meta dict from {}'.format(self.metapath))
 
         if 'Version' in metad:
-            self.release_version = metad['Version']
-            if not self.release_version.startswith('v'):
-                self.release_version = 'v{}'.format(self.release_version)
+            self.release_version = metad['Version'].strip('v')
 
         self.num_components = len(self.alignment_dct)
         if self.num_components == 0:


### PR DESCRIPTION
Previously xtrack pairnames were not properly parsed from the tile meta.txt files and never made it into the `SetsmTile.component_list` attribute.

@klassenjs requested that the `SetsmTile.release_version` attribute always starts with a 'v' prefix (like 'v2.0') as it is when the attribute is set through parsing of the mosaic tile filename.