### PR TITLE
(WIP) Round DEM and MAD raster values to 1/128 meters, and add new standard `-ovr NONE` arg to GDAL calls

### DIFF
--- a/apply_setsm_registration.py
+++ b/apply_setsm_registration.py
@@ -247,14 +247,14 @@ def apply_reg(srcfp, args):
     
     if not srcfp.endswith("dem.tif"):
         if os.path.isfile(reg_vrt) and not os.path.isfile(temp_fp):
-            cmd = 'gdal_translate -projwin {} -co COMPRESS=LZW -co TILED=YES "{}" "{}"'.format(target_extent,reg_vrt,dstfp)
+            cmd = 'gdalwarp -ovr NONE -projwin {} -co COMPRESS=LZW -co TILED=YES "{}" "{}"'.format(target_extent,reg_vrt,dstfp)
             if not args.dryrun:
                 logger.info(cmd)
                 subprocess.call(cmd,shell=True)
     
     else:
         if os.path.isfile(reg_vrt) and not os.path.isfile(temp_fp):
-            cmd = 'gdal_translate -projwin {} -co COMPRESS=LZW -co TILED=YES "{}" "{}"'.format(target_extent,reg_vrt,temp_fp)
+            cmd = 'gdalwarp -ovr NONE -projwin {} -co COMPRESS=LZW -co TILED=YES "{}" "{}"'.format(target_extent,reg_vrt,temp_fp)
             if not args.dryrun:
                 logger.info(cmd)
                 subprocess.call(cmd,shell=True)

--- a/apply_setsm_registration.py
+++ b/apply_setsm_registration.py
@@ -234,8 +234,9 @@ def apply_reg(srcfp, args):
         geom = ogr.Geometry(ogr.wkbPolygon)
         geom.AddGeometry(ring)
         
-        # [-projwin ulx uly lrx lry]
-        target_extent = "{} {} {} {}".format(minx, maxy, maxx, miny)
+        # -projwin ulx uly lrx lry
+        # -te xmin ymin xmax ymax
+        target_extent = "{} {} {} {}".format(minx, miny, maxx, maxy)
                 
         vds = VRTdrv.CreateCopy(reg_vrt,sds,0)
         dgtf = (trans_origin_x,gtf[1],gtf[2],trans_origin_y,gtf[4],gtf[5])
@@ -247,14 +248,14 @@ def apply_reg(srcfp, args):
     
     if not srcfp.endswith("dem.tif"):
         if os.path.isfile(reg_vrt) and not os.path.isfile(temp_fp):
-            cmd = 'gdalwarp -ovr NONE -projwin {} -co COMPRESS=LZW -co TILED=YES "{}" "{}"'.format(target_extent,reg_vrt,dstfp)
+            cmd = 'gdalwarp -ovr NONE -te {} -co COMPRESS=LZW -co TILED=YES "{}" "{}"'.format(target_extent,reg_vrt,dstfp)
             if not args.dryrun:
                 logger.info(cmd)
                 subprocess.call(cmd,shell=True)
     
     else:
         if os.path.isfile(reg_vrt) and not os.path.isfile(temp_fp):
-            cmd = 'gdalwarp -ovr NONE -projwin {} -co COMPRESS=LZW -co TILED=YES "{}" "{}"'.format(target_extent,reg_vrt,temp_fp)
+            cmd = 'gdalwarp -ovr NONE -te {} -co COMPRESS=LZW -co TILED=YES "{}" "{}"'.format(target_extent,reg_vrt,temp_fp)
             if not args.dryrun:
                 logger.info(cmd)
                 subprocess.call(cmd,shell=True)

--- a/divide_setsm_tiles.py
+++ b/divide_setsm_tiles.py
@@ -276,13 +276,15 @@ def divide_tile(src, args):
                 dstfp = '{}_{}m{}_{}{}.tif'.format(tile_base[:-3], args.res, version_str, reg_str, component)
                 logger.info("Building {}".format(dstfp))
                 if not os.path.isfile(dstfp):
-                    cmd = 'gdal_translate  -stats -co tiled=yes -co bigtiff=yes -co compress=lzw -tr {2} {2} -r {7} -projwin {3} {4} {5} {6} {0} {1}'.format(srcfp, dstfp, args.res, minx, maxy, maxx, miny, resample)
+                    cmd = 'gdalwarp -ovr NONE -co tiled=yes -co bigtiff=yes -co compress=lzw -tr {2} {2} -r {7} -te {3} {4} {5} {6} {0} {1}'.format(
+                        srcfp, dstfp, args.res, minx, miny, maxx, maxy, resample
+                    )
                     logger.info(cmd)
                     subprocess.call(cmd, shell=True)
 
                     if mask:
                         if os.path.isfile(dstfp) and os.path.isfile(mask):
-                            cmd = 'gdalwarp {} {}'.format(mask, dstfp)
+                            cmd = 'gdalwarp -ovr NONE {} {}'.format(mask, dstfp)
                             logger.info(cmd)
                             subprocess.call(cmd, shell=True)
                             os.remove(mask)
@@ -312,13 +314,15 @@ def divide_tile(src, args):
                         dstfp = '{}_{}_{}m{}_{}{}.tif'.format(tile_base[:-3], subtile_name, args.res, version_str, reg_str, component)
                         logger.info("Building {}".format(dstfp))
                         if not os.path.isfile(dstfp):
-                            cmd = 'gdal_translate  -stats -co tiled=yes -co bigtiff=yes -co compress=lzw -tr {2} {2} -r {7} -projwin {3} {4} {5} {6} {0} {1}'.format(srcfp, dstfp, args.res, xorigin, yorigin+tilesizey, xorigin+tilesizex, yorigin, resample)
+                            cmd = 'gdalwarp -ovr NONE -co tiled=yes -co bigtiff=yes -co compress=lzw -tr {2} {2} -r {7} -te {3} {4} {5} {6} {0} {1}'.format(
+                                srcfp, dstfp, args.res, xorigin, yorigin, xorigin+tilesizex,  yorigin+tilesizey, resample
+                            )
                             logger.info(cmd)
                             subprocess.call(cmd, shell=True)
 
                         if mask:
                             if os.path.isfile(dstfp) and os.path.isfile(mask):
-                                cmd = 'gdalwarp {} {}'.format(mask, dstfp)
+                                cmd = 'gdalwarp -ovr NONE {} {}'.format(mask, dstfp)
                                 logger.info(cmd)
                                 subprocess.call(cmd, shell=True)
 

--- a/generate_browse_setsm.py
+++ b/generate_browse_setsm.py
@@ -165,15 +165,15 @@ def resample_setsm(dem, args):
         logger.info("Resampling {}".format(dem))
         #print low_res_dem
         if args.component == 'dem':
-            cmd = 'gdalwarp -tap -q -tr {0} {0} -r bilinear -dstnodata -9999 "{1}" "{2}"'.format(args.resolution, dem, tempfile)
+            cmd = 'gdalwarp -ovr NONE -tap -q -tr {0} {0} -r bilinear -dstnodata -9999 "{1}" "{2}"'.format(args.resolution, dem, tempfile)
             cmd2 = 'gdaldem hillshade -q -z 3 -compute_edges -of {2} -co TILED=YES -co BIGTIFF=YES -co COMPRESS=LZW "{0}" "{1}"'.format(tempfile, low_res_dem, args.format)
             
         elif args.component == 'matchtag':
-            cmd = 'gdal_translate -q -tr {0} {0} -of {3} -r near -a_nodata 0 "{1}" "{2}"'.format(args.resolution, dem, low_res_dem, args.format)
+            cmd = 'gdalwarp -ovr NONE -q -tr {0} {0} -of {3} -r near -dstnodata 0 "{1}" "{2}"'.format(args.resolution, dem, low_res_dem, args.format)
             cmd2 = None
             
         else:
-            cmd = 'gdal_translate -tap -q -ot Byte -scale -tr {0} {0} -of {3} -r cubic -a_nodata 0 "{1}" "{2}"'.format(args.resolution, dem, low_res_dem, args.format)
+            cmd = 'gdalwarp -ovr NONE -tap -q -ot Byte -tr {0} {0} -of {3} -r cubic -dstnodata 0 "{1}" "{2}"'.format(args.resolution, dem, low_res_dem, args.format)
             cmd2 = None
             
         #print cmd

--- a/generate_browse_setsm.py
+++ b/generate_browse_setsm.py
@@ -173,7 +173,7 @@ def resample_setsm(dem, args):
             cmd2 = None
             
         else:
-            cmd = 'gdal_translate -q -ot Byte -dstnodata 0 "{0}" "{1}"'.format(dem, tempfile)
+            cmd = 'gdal_translate -q -ot Byte -scale -dstnodata 0 "{0}" "{1}"'.format(dem, tempfile)
             cmd2 = 'gdalwarp -ovr NONE -tap -q -tr {0} {0} -of {3} -r cubic -dstnodata 0 "{1}" "{2}"'.format(
                 args.resolution, tempfile, low_res_dem, args.format
             )

--- a/generate_browse_setsm.py
+++ b/generate_browse_setsm.py
@@ -173,9 +173,11 @@ def resample_setsm(dem, args):
             cmd2 = None
             
         else:
-            cmd = 'gdalwarp -ovr NONE -tap -q -ot Byte -tr {0} {0} -of {3} -r cubic -dstnodata 0 "{1}" "{2}"'.format(args.resolution, dem, low_res_dem, args.format)
-            cmd2 = None
-            
+            cmd = 'gdal_translate -q -ot Byte -dstnodata 0 "{0}" "{1}"'.format(dem, tempfile)
+            cmd2 = 'gdalwarp -ovr NONE -tap -q -tr {0} {0} -of {3} -r cubic -dstnodata 0 "{1}" "{2}"'.format(
+                args.resolution, tempfile, low_res_dem, args.format
+            )
+
         #print cmd
         if not args.dryrun:
             taskhandler.exec_cmd(cmd)

--- a/reproject_setsm.py
+++ b/reproject_setsm.py
@@ -156,14 +156,14 @@ def resample_setsm(raster, dstdir, args):
             logger.info("Reprojecting {}".format(component))
             #print new_raster
             if suffix == 'dem.tif':
-                cmd = ('gdalwarp -q -tap -t_srs EPSG:{0} -tr {3} {3} -r bilinear -co tiled=yes -co compress=lzw '
+                cmd = ('gdalwarp -q -ovr NONE -tap -t_srs EPSG:{0} -tr {3} {3} -r bilinear -co tiled=yes -co compress=lzw '
                       '-co bigtiff=yes "{1}" "{2}"'.format(args.epsg, component, new_raster, args.resolution))
                 if not args.dryrun:
                     taskhandler.exec_cmd(cmd)
             elif suffix == 'meta.txt':
                 resample_stripmeta(component, new_raster, args.epsg)
             else:
-                cmd = ('gdalwarp -q -tap -t_srs EPSG:{0} -tr {3} {3} -r near -co tiled=yes -co compress=lzw '
+                cmd = ('gdalwarp -q -ovr NONE -tap -t_srs EPSG:{0} -tr {3} {3} -r near -co tiled=yes -co compress=lzw '
                       '-co bigtiff=yes "{1}" "{2}"'.format(args.epsg, component, new_raster, args.resolution))
                 if not args.dryrun:
                     taskhandler.exec_cmd(cmd)

--- a/resample_setsm.py
+++ b/resample_setsm.py
@@ -144,7 +144,7 @@ def resample_setsm(dem, args):
         logger.info("Resampling {}".format(dem))
         #print low_res_dem
         resampling_method = 'bilinear' if args.component == 'dem' else 'near'
-        cmd = 'gdalwarp -q -co tiled=yes -co compress=lzw -r {3} -tr {0} {0} "{1}" "{2}"'.format(args.resolution, dem, low_res_dem, resampling_method)
+        cmd = 'gdalwarp -q -ovr NONE -co tiled=yes -co compress=lzw -r {3} -tr {0} {0} "{1}" "{2}"'.format(args.resolution, dem, low_res_dem, resampling_method)
         #print cmd
         if not args.dryrun:
             taskhandler.exec_cmd(cmd)

--- a/resample_setsm_tiles.py
+++ b/resample_setsm_tiles.py
@@ -429,7 +429,7 @@ def process_raster(inputp, output, component, args):
 
                 if args.output_cogs:
                     # Convert gdal_calc.py GTiff output to COG format
-                    cmd = 'gdalwarp -q -ovr NONE {2} "{0}" "{1}"'.format(
+                    cmd = 'gdalwarp -q -ovr NONE -overwrite {2} "{0}" "{1}"'.format(
                         output_tmp, output, cos_cog
                     )
                     logger.debug(cmd)

--- a/resample_setsm_tiles.py
+++ b/resample_setsm_tiles.py
@@ -20,13 +20,13 @@ res_min = 0.5
 res_max = 5000
 output_settings = {
     ## component: (resampling strategy, overview resampling, predictor, nodata value)
-    'dem':      ('bilinear', 'bilinear', 'yes', -9999),
-    'browse':   ('cubic', 'cubic', 'yes', 0),
-    'count':    ('near', 'nearest', 'no', 0),
-    'countmt':  ('near', 'nearest', 'no', 0),
-    'mad':      ('bilinear', 'bilinear', 'yes', -9999),
-    'maxdate':  ('near', 'nearest', 'no', 0),
-    'mindate':  ('near', 'nearest', 'no', 0)
+    'dem':      ('bilinear', 'bilinear', 3, -9999),
+    'browse':   ('cubic', 'cubic', 2, 0),
+    'count':    ('near', 'nearest', 1, 0),
+    'countmt':  ('near', 'nearest', 1, 0),
+    'mad':      ('bilinear', 'bilinear', 3, -9999),
+    'maxdate':  ('near', 'nearest', 1, 0),
+    'mindate':  ('near', 'nearest', 1, 0)
 }
 suffixes = list(output_settings.keys())
 

--- a/resample_setsm_tiles.py
+++ b/resample_setsm_tiles.py
@@ -415,7 +415,7 @@ def process_raster(inputp, output, component, args):
             if not args.dryrun:
                 taskhandler.exec_cmd(cmd)
 
-            if component in ('dem', 'mad'):
+            if component in ('dem.tif', 'mad.tif'):
                 # Round these rasters to 1/128 meters to optimize compression
                 output_tmp = '{}_tmp{}'.format(*os.path.splitext(output))
 

--- a/resample_setsm_tiles.py
+++ b/resample_setsm_tiles.py
@@ -369,7 +369,7 @@ def merge_rasters(inputps, output, component, args):
                 '-co compress=lzw -co predictor={}'.format(predictor)
 
     cos = cos_cog if args.output_cogs else cos_gtiff
-    cmd = 'gdal_translate -q -ovr NONE {} "{}" "{}"'.format(
+    cmd = 'gdalwarp -q -ovr NONE {} "{}" "{}"'.format(
         cos, vrt, output
     )
 
@@ -429,7 +429,7 @@ def process_raster(inputp, output, component, args):
 
                 if args.output_cogs:
                     # Convert gdal_calc.py GTiff output to COG format
-                    cmd = 'gdal_translate -q -ovr NONE {2} "{0}" "{1}"'.format(
+                    cmd = 'gdalwarp -q -ovr NONE {2} "{0}" "{1}"'.format(
                         output_tmp, output, cos_cog
                     )
                     logger.debug(cmd)


### PR DESCRIPTION
Addresses issue https://github.com/PolarGeospatialCenter/pgcdemtools/issues/59.

- Round DEM and MAD values to 1/128 meters to greatly increase compression efficiency.
- Add `-ovr NONE` to gdalwarp and gdal_translate calls. Only when downsampling is this necessary to avoid error propagation when overviews are used for resampling. But add it to all calls just to get used to it.
- Add LZW predictor setting to GTiff output settings.
- Add debug mode to `resample_setsm_tiles.py` script.