### PR TITLE
Add OpenFileGDB capability

### DIFF
--- a/index_setsm.py
+++ b/index_setsm.py
@@ -233,10 +233,12 @@ def main():
         ogrDriver = None
         for ogr_driver_str in ogr_driver_list:
             ogrDriver = ogr.GetDriverByName(ogr_driver_str)
+            if ogrDriver is not None:
+                break
         if ogrDriver is None:
             parser.error("Driver(s) not available: {}".format(', '.join(ogr_driver_list)))
         else:
-            logger.info("Format Driver selected: {}".format(ogr_driver_str))
+            logger.info("Driver selected: {}".format(ogr_driver_str))
 
         #### Get Config file contents
         try:

--- a/index_setsm.py
+++ b/index_setsm.py
@@ -226,13 +226,17 @@ def main():
     ## If not writing to JSON, get OGR driver, ds name, and layer name
     else:
         try:
-            ogr_driver_str, dst_dsp, dst_lyr = utils.get_source_names2(dst)
+            ogr_driver_list, dst_dsp, dst_lyr = utils.get_source_names2(dst)
         except RuntimeError as e:
             parser.error(e)
 
-        ogrDriver = ogr.GetDriverByName(ogr_driver_str)
+        ogrDriver = None
+        for ogr_driver_str in ogr_driver_list:
+            ogrDriver = ogr.GetDriverByName(ogr_driver_str)
         if ogrDriver is None:
-            parser.error("Driver is not available: {}".format(ogr_driver_str))
+            parser.error("Driver(s) not available: {}".format(', '.join(ogr_driver_list)))
+        else:
+            logger.info("Format Driver selected: {}".format(ogr_driver_str))
 
         #### Get Config file contents
         try:
@@ -261,7 +265,7 @@ def main():
                 sys.exit(-1)
 
         #### Set dataset path is SHP or GDB
-        elif ogr_driver_str in ("ESRI Shapefile","FileGDB"):
+        elif ogr_driver_str in ("ESRI Shapefile", "FileGDB", "OpenFileGDB"):
             dst_ds = dst_dsp
 
         else:
@@ -439,7 +443,7 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
         else:
             ds = ogrDriver.CreateDataSource(dst_ds)
 
-    elif ogr_driver_str == 'FileGDB':
+    elif ogr_driver_str in ['FileGDB', 'OpenFileGDB']:
         max_fld_width = 1024
         if os.path.isdir(dst_ds):
             ds = ogrDriver.Open(dst_ds,1)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -505,12 +505,12 @@ def get_source_names2(src_str):
     src_str_abs = os.path.abspath(src_str)
 
     if src_str.lower().endswith(".shp"):
-        driver = "ESRI Shapefile"
+        driver = ["ESRI Shapefile"]
         src_ds = src_str_abs
         src_lyr = os.path.splitext(os.path.basename(src_str_abs))[0]
 
     elif ".gdb" in src_str.lower():
-        driver = "FileGDB"
+        driver = ["FileGDB", "OpenFileGDB"]
         if not src_str_abs.lower().endswith(".gdb"):
             src_ds, src_lyr = re.split(r"(?<=\.gdb)/", src_str_abs, re.I)
         else:
@@ -518,7 +518,7 @@ def get_source_names2(src_str):
             src_lyr = os.path.splitext(os.path.basename(src_str))[0]
 
     elif src_str.lower().startswith("pg:"):
-        driver = "PostgreSQL"
+        driver = ["PostgreSQL"]
         pfx, src_ds, src_lyr = src_str.split(":")
 
     else:


### PR DESCRIPTION
Looks for either `FileGDB` or `OpenFileGDB` drivers when writing out gdb indexes.