### PR TITLE
More complete check of `SetsmScene` source file existence

### DIFF
--- a/lib/dem.py
+++ b/lib/dem.py
@@ -206,11 +206,41 @@ class SetsmScene(object):
             # set shared attributes
             self.id = self.sceneid
 
-            if not os.path.isfile(self.ortho) \
-            or not os.path.isfile(self.matchtag) \
-            or not os.path.isfile(self.metapath) \
-            or not (os.path.isfile(self.dem) or os.path.isfile(self.lsf_dem)):
+            dem_files = [
+                self.lsf_dem,
+                self.dem,
+                self.dem_edge_masked,
+            ]
+            req_files = [
+                self.ortho,
+                self.matchtag,
+                self.metapath,
+            ]
+            opt_files = [
+                self.ortho2,
+                self.dspinfo,
+            ]
+
+            dem_exists = False
+            for f in dem_files:
+                if os.path.isfile(f):
+                    dem_exists = True
+                    if os.path.getsize(f) == 0:
+                        raise RuntimeError("DEM file is empty: {}".format(f))
+            if not dem_exists:
                 raise RuntimeError("DEM is part of an incomplete set: {}".format(self.sceneid))
+
+            for f in req_files:
+                if os.path.isfile(f):
+                    if os.path.getsize(f) == 0:
+                        raise RuntimeError("DEM file is empty: {}".format(f))
+                else:
+                    raise RuntimeError("DEM is part of an incomplete set: {}".format(self.sceneid))
+
+            for f in opt_files:
+                if os.path.isfile(f):
+                    if os.path.getsize(f) == 0:
+                        raise RuntimeError("DEM file is empty: {}".format(f))
 
             #### parse name
             match = setsm_scene_pattern.match(self.srcfn)


### PR DESCRIPTION
Upon creating a `SetsmScene` record, check source scene component files:
- One of the possible three DEM rasters exists and is not zero-length
- All three required {ortho, matchtag, meta} files exist and are not zero-length
- If either the `ortho2.tif` or `info50cm.txt` file exist, it is not zero-length