### PR TITLE
Skip over unique constraint duplicate record errors, adjust error logging in index_setsm.py

### DIFF
--- a/index_setsm.py
+++ b/index_setsm.py
@@ -989,7 +989,7 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
                                                 gdal_errmsg = utils.GDAL_ERROR_HANDLER.err_msg
                                                 if "duplicate key value violates unique constraint" in gdal_errmsg:
                                                     duplicate_record_cnt += 1
-                                                    log_errmsg = "Skipping duplciate record error in OGR CreateFeature call:\n{}".format(gdal_errmsg)
+                                                    log_errmsg = "Skipping duplicate record error in OGR CreateFeature call:\n{}".format(gdal_errmsg)
                                                     if duplicate_record_cnt <= 30:
                                                         logger.error(log_errmsg)
                                                         if duplicate_record_cnt == 30:

--- a/index_setsm.py
+++ b/index_setsm.py
@@ -463,6 +463,12 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
 
     dsp_orig_status = args.status_dsp_record_mode_orig if args.status_dsp_record_mode_orig else status
 
+    fld_def_location_fwidth_gdb = None
+    for f in fld_defs:
+        if f.fname.upper() == 'LOCATION':
+            fld_def_location_fwidth_gdb = min(f.fwidth, 1024)
+            break
+
     if ds is not None:
 
         ## Create table if it does not exist
@@ -907,6 +913,12 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
                                             val, fld, fwidths[fld]
                                         ))
                                         valid_record = False
+                                        if fld.upper() == 'LOCATION' and ogr_driver_str == 'ESRI Shapefile':
+                                            if fld_def_location_fwidth_gdb is not None and fld_def_location_fwidth_gdb > fwidths[fld]:
+                                                logger.warning("Tip: LOCATION field values can be longer (width={}) \
+                                                    if you write to a non-Shapefile index such as FileGDB or PostgreSQL table".format(
+                                                    fld_def_location_fwidth_gdb
+                                                ))
                                 else:
                                     logger.warning("Field {} is not in target table. Feature skipped".format(fld))
                                     valid_record = False

--- a/index_setsm.py
+++ b/index_setsm.py
@@ -909,7 +909,7 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
                             for fld,val in attrib_map.items():
                                 if fld in fwidths:
                                     if isinstance(val, str) and len(val) > fwidths[fld]:
-                                        logger.warning("Attribute value {} is too long for field {} (width={}). Feature skipped".format(
+                                        logger.error("Attribute value {} is too long for field {} (width={}). Feature skipped".format(
                                             val, fld, fwidths[fld]
                                         ))
                                         valid_record = False
@@ -920,7 +920,7 @@ def write_to_ogr_dataset(ogr_driver_str, ogrDriver, dst_ds, dst_lyr, groups, pai
                                                     fld_def_location_fwidth_gdb
                                                 ))
                                 else:
-                                    logger.warning("Field {} is not in target table. Feature skipped".format(fld))
+                                    logger.error("Field {} is not in target table. Feature skipped".format(fld))
                                     valid_record = False
 
                                 if sys.version_info[0] < 3:  # force unicode to str for a bug in Python2 GDAL's SetField.

--- a/index_setsm.py
+++ b/index_setsm.py
@@ -387,11 +387,14 @@ def main():
             temp_records = read_json(os.path.join(src_fp),args.mode)
             records.extend(temp_records)
         else:
+            record = None
             try:
                 record = dem_class(src_fp)
                 record.get_dem_info()
-            except RuntimeError as e:
-                logger.error( e )
+            except Exception as e:
+                logger.error(e)
+                if record is not None and hasattr(record, 'srcfp'):
+                    logger.error("Error encountered on DEM record: {}".format(record.srcfp))
             else:
                 ## Check if DEM is a DSP DEM, dsp-record mode includes 'orig', and the original DEM data is unavailable
                 if args.mode == 'scene' and record.is_dsp and not os.path.isfile(record.dspinfo) \

--- a/lib/dem.py
+++ b/lib/dem.py
@@ -160,6 +160,7 @@ class SetsmScene(object):
                 self.epsg = get_epsg(self.proj4)
 
         else:
+            self.srcfp = metapath
             self.srcdir, self.srcfn = os.path.split(metapath)
             self.sceneid = self.srcfn[:-9]
 
@@ -185,7 +186,6 @@ class SetsmScene(object):
 
             # set shared attributes
             self.id = self.sceneid
-            self.srcfp = self.metapath
 
             if not os.path.isfile(self.ortho) \
             or not os.path.isfile(self.matchtag) \

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -61,13 +61,22 @@ logger = get_logger()
 ## GDAL error handler setup
 class GdalErrorHandler(object):
     def __init__(self, catch_warnings=None, print_uncaught_warnings=None):
+        self.catch_warnings = catch_warnings if catch_warnings is not None else True
+        self.print_warnings = print_uncaught_warnings if print_uncaught_warnings is not None else True
+        self.errored = False
+        self.err_level = None
+        self.err_no = None
+        self.err_msg = None
+        self.reset_error_state()
+
+    def reset_error_state(self):
+        self.errored = False
         self.err_level = gdal.CE_None
         self.err_no = 0
         self.err_msg = ''
-        self.catch_warnings = catch_warnings if catch_warnings is not None else True
-        self.print_warnings = print_uncaught_warnings if print_uncaught_warnings is not None else True
 
     def handler(self, err_level, err_no, err_msg):
+        self.errored = True
         self.err_level = err_level
         self.err_no = err_no
         self.err_msg = err_msg


### PR DESCRIPTION
-- IMPORTANT NOTE --
The most important change in this PR is in how index_setsm.py handles the "duplicate key value violates unique constraint" error when add records to the target table. Previously, the entire index_setsm.py process would error out upon hitting the first record that trips the unique constraint error. Now it will just print error messages and skip over those records.


See individual commits for details on the particular tweaks.

This needs more testing, but I think these changes touch on some really important areas for improvement in the error handling.

I believe NASA has been running with these changes applied as a patch to their pgcdemtools code.