### PR TITLE
Example pystac-client code for download from AWS STAC catalog

### DIFF
--- a/download_rema.ipynb
+++ b/download_rema.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,18 +165,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "[<CollectionClient id=arcticdem>,\n",
-       " <CollectionClient id=earthdem>,\n",
-       " <CollectionClient id=rema>]"
-      ]
+      "text/plain": "[<CollectionClient id=arcticdem>,\n <CollectionClient id=earthdem>,\n <CollectionClient id=rema>]"
      },
-     "execution_count": 133,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -187,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -195,16 +191,16 @@
      "evalue": "This catalog does not support search because it does not conform to \"ConformanceClasses.ITEM_SEARCH\"",
      "output_type": "error",
      "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNotImplementedError\u001b[0m                       Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn [134], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m stac\u001b[38;5;241m.\u001b[39msearch(\n\u001b[1;32m      2\u001b[0m     intersects\u001b[38;5;241m=\u001b[39maoi_geom_4326,\n\u001b[1;32m      3\u001b[0m     datetime\u001b[38;5;241m=\u001b[39mdaterange,\n\u001b[1;32m      4\u001b[0m     collections\u001b[38;5;241m=\u001b[39m[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mrema\u001b[39m\u001b[38;5;124m\"\u001b[39m],\n\u001b[1;32m      5\u001b[0m     limit\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m500\u001b[39m,      \u001b[38;5;66;03m# number of items per page of results\u001b[39;00m\n\u001b[1;32m      6\u001b[0m     max_items\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1e9\u001b[39m,  \u001b[38;5;66;03m# abritrarily large max_items to return.\u001b[39;00m\n\u001b[1;32m      7\u001b[0m )\n",
-      "File \u001b[0;32m~/software/miniconda3/envs/geomamba/lib/python3.10/site-packages/pystac_client/client.py:422\u001b[0m, in \u001b[0;36mClient.search\u001b[0;34m(self, method, max_items, limit, ids, collections, bbox, intersects, datetime, query, filter, filter_lang, sortby, fields)\u001b[0m\n\u001b[1;32m    321\u001b[0m \u001b[38;5;124;03m\"\"\"Query the ``/search`` endpoint using the given parameters.\u001b[39;00m\n\u001b[1;32m    322\u001b[0m \n\u001b[1;32m    323\u001b[0m \u001b[38;5;124;03mThis method returns an :class:`~pystac_client.ItemSearch` instance. See that\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    419\u001b[0m \u001b[38;5;124;03m        a ``\"rel\"`` type of ``\"search\"``.\u001b[39;00m\n\u001b[1;32m    420\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    421\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_conforms_to(ConformanceClasses\u001b[38;5;241m.\u001b[39mITEM_SEARCH):\n\u001b[0;32m--> 422\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mNotImplementedError\u001b[39;00m(\n\u001b[1;32m    423\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mThis catalog does not support search because it \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    424\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mdoes not conform to \u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mConformanceClasses\u001b[38;5;241m.\u001b[39mITEM_SEARCH\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    425\u001b[0m     )\n\u001b[1;32m    426\u001b[0m search_link \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mget_search_link()\n\u001b[1;32m    427\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m search_link:\n",
-      "\u001b[0;31mNotImplementedError\u001b[0m: This catalog does not support search because it does not conform to \"ConformanceClasses.ITEM_SEARCH\""
+      "\u001B[1;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[1;31mNotImplementedError\u001B[0m                       Traceback (most recent call last)",
+      "Cell \u001B[1;32mIn [6], line 1\u001B[0m\n\u001B[1;32m----> 1\u001B[0m \u001B[43mpgcstac\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43msearch\u001B[49m\u001B[43m(\u001B[49m\n\u001B[0;32m      2\u001B[0m \u001B[43m    \u001B[49m\u001B[43mintersects\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43maoi_geom_4326\u001B[49m\u001B[43m,\u001B[49m\n\u001B[0;32m      3\u001B[0m \u001B[43m    \u001B[49m\u001B[43mdatetime\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mdaterange\u001B[49m\u001B[43m,\u001B[49m\n\u001B[0;32m      4\u001B[0m \u001B[43m    \u001B[49m\u001B[43mcollections\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43m[\u001B[49m\u001B[38;5;124;43m\"\u001B[39;49m\u001B[38;5;124;43mrema\u001B[39;49m\u001B[38;5;124;43m\"\u001B[39;49m\u001B[43m]\u001B[49m\u001B[43m,\u001B[49m\n\u001B[0;32m      5\u001B[0m \u001B[43m    \u001B[49m\u001B[43mlimit\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[38;5;241;43m500\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m      \u001B[49m\u001B[38;5;66;43;03m# number of items per page of results\u001B[39;49;00m\n\u001B[0;32m      6\u001B[0m \u001B[43m    \u001B[49m\u001B[43mmax_items\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[38;5;241;43m1e9\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m  \u001B[49m\u001B[38;5;66;43;03m# abritrarily large max_items to return.\u001B[39;49;00m\n\u001B[0;32m      7\u001B[0m \u001B[43m)\u001B[49m\n",
+      "File \u001B[1;32mC:\\ProgramData\\Miniconda3\\envs\\pgc\\lib\\site-packages\\pystac_client\\client.py:422\u001B[0m, in \u001B[0;36mClient.search\u001B[1;34m(self, method, max_items, limit, ids, collections, bbox, intersects, datetime, query, filter, filter_lang, sortby, fields)\u001B[0m\n\u001B[0;32m    321\u001B[0m \u001B[38;5;124;03m\"\"\"Query the ``/search`` endpoint using the given parameters.\u001B[39;00m\n\u001B[0;32m    322\u001B[0m \n\u001B[0;32m    323\u001B[0m \u001B[38;5;124;03mThis method returns an :class:`~pystac_client.ItemSearch` instance. See that\u001B[39;00m\n\u001B[1;32m   (...)\u001B[0m\n\u001B[0;32m    419\u001B[0m \u001B[38;5;124;03m        a ``\"rel\"`` type of ``\"search\"``.\u001B[39;00m\n\u001B[0;32m    420\u001B[0m \u001B[38;5;124;03m\"\"\"\u001B[39;00m\n\u001B[0;32m    421\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;129;01mnot\u001B[39;00m \u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39m_conforms_to(ConformanceClasses\u001B[38;5;241m.\u001B[39mITEM_SEARCH):\n\u001B[1;32m--> 422\u001B[0m     \u001B[38;5;28;01mraise\u001B[39;00m \u001B[38;5;167;01mNotImplementedError\u001B[39;00m(\n\u001B[0;32m    423\u001B[0m         \u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mThis catalog does not support search because it \u001B[39m\u001B[38;5;124m\"\u001B[39m\n\u001B[0;32m    424\u001B[0m         \u001B[38;5;124mf\u001B[39m\u001B[38;5;124m'\u001B[39m\u001B[38;5;124mdoes not conform to \u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;132;01m{\u001B[39;00mConformanceClasses\u001B[38;5;241m.\u001B[39mITEM_SEARCH\u001B[38;5;132;01m}\u001B[39;00m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124m'\u001B[39m\n\u001B[0;32m    425\u001B[0m     )\n\u001B[0;32m    426\u001B[0m search_link \u001B[38;5;241m=\u001B[39m \u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39mget_search_link()\n\u001B[0;32m    427\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m search_link:\n",
+      "\u001B[1;31mNotImplementedError\u001B[0m: This catalog does not support search because it does not conform to \"ConformanceClasses.ITEM_SEARCH\""
      ]
     }
    ],
    "source": [
-    "stac.search(\n",
+    "pgcstac.search(\n",
     "    intersects=aoi_geom_4326,\n",
     "    datetime=daterange,\n",
     "    collections=[\"rema\"],\n",
@@ -216,16 +212,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (geomamba)",
+   "name": "python3",
    "language": "python",
-   "name": "geomamba"
+   "display_name": "Python 3 (ipykernel)"
   },
   "language_info": {
    "codemirror_mode": {

--- a/download_rema.ipynb
+++ b/download_rema.ipynb
@@ -1,0 +1,258 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import os, glob\n",
+    "\n",
+    "import geopandas as gpd\n",
+    "import pandas as pd\n",
+    "# import rasterio as rs\n",
+    "# import rioxarray as rxr\n",
+    "# import numpy as np\n",
+    "# import boto3\n",
+    "\n",
+    "# from rasterio.session import AWSSession\n",
+    "# from rasterio.enums import Resampling\n",
+    "from pystac_client import Client\n",
+    "from shapely.geometry import shape, box\n",
+    "\n",
+    "# import matplotlib.pyplot as plt\n",
+    "# %matplotlib notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Get search parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# boundaries of thwaites eastern shelf\n",
+    "aoi_bounds = -1609000,-465000,-1542000,-415000\n",
+    "\n",
+    "# get date range\n",
+    "date1 = '2019-01-01'\n",
+    "date2 = '2019-03-01'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Process to search inputs\n",
+    "aoi_geom = box(*aoi_bounds)\n",
+    "aoi_gdf = gpd.GeoDataFrame(geometry=[aoi_geom], crs=3031)\n",
+    "aoi_geom_4326 = aoi_gdf.to_crs(4326).geometry.values[0]\n",
+    "\n",
+    "daterange= f'{date1}/{date2}'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Search Landsat AWS STAC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Open client instance\n",
+    "landsat_stac_url = 'https://landsatlook.usgs.gov/stac-server'\n",
+    "landsatlookstac = Client.open(landsat_stac_url, headers=[])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<CollectionClient id=landsat-c2l2-sr>,\n",
+       " <CollectionClient id=landsat-c2l2-st>,\n",
+       " <CollectionClient id=landsat-c2ard-st>,\n",
+       " <CollectionClient id=landsat-c2l2alb-bt>,\n",
+       " <CollectionClient id=landsat-c2l3-fsca>,\n",
+       " <CollectionClient id=landsat-c2ard-bt>,\n",
+       " <CollectionClient id=landsat-c2l1>,\n",
+       " <CollectionClient id=landsat-c2l3-ba>,\n",
+       " <CollectionClient id=landsat-c2l2alb-st>,\n",
+       " <CollectionClient id=landsat-c2ard-sr>,\n",
+       " <CollectionClient id=landsat-c2l2alb-sr>,\n",
+       " <CollectionClient id=landsat-c2l2alb-ta>,\n",
+       " <CollectionClient id=landsat-c2l3-dswe>,\n",
+       " <CollectionClient id=landsat-c2ard-ta>]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Assess and select a collection\n",
+    "[i for i in landsatlookstac.get_collections()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search = landsatlookstac.search(\n",
+    "    intersects=aoi_geom_4326,\n",
+    "    datetime=daterange,\n",
+    "    collections=[\"landsat-c2l1\"],\n",
+    "    limit=500,      # number of items per page of results\n",
+    "    max_items=1e9,  # abritrarily large max_items to return.\n",
+    ")\n",
+    "\n",
+    "items = [i.to_dict() for i in search.get_items()]\n",
+    "items = pd.json_normalize(items)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# # Print pandas dataframe of search results\n",
+    "# items"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Search PGC AWS Stac"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 132,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pgc_stac_url = 'https://polargeospatialcenter.github.io/stac-browser'\n",
+    "# pgc_stac_url = 'https://pgc-opendata-dems.s3.us-west-2.amazonaws.com/rema/mosaics.json'\n",
+    "pgc_stac_url = 'https://pgc-opendata-dems.s3.us-west-2.amazonaws.com/pgc-data-stac.json'\n",
+    "\n",
+    "pgcstac = Client.open(pgc_stac_url, headers=[])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 133,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<CollectionClient id=arcticdem>,\n",
+       " <CollectionClient id=earthdem>,\n",
+       " <CollectionClient id=rema>]"
+      ]
+     },
+     "execution_count": 133,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[i for i in pgcstac.get_collections()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 134,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NotImplementedError",
+     "evalue": "This catalog does not support search because it does not conform to \"ConformanceClasses.ITEM_SEARCH\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNotImplementedError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn [134], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m stac\u001b[38;5;241m.\u001b[39msearch(\n\u001b[1;32m      2\u001b[0m     intersects\u001b[38;5;241m=\u001b[39maoi_geom_4326,\n\u001b[1;32m      3\u001b[0m     datetime\u001b[38;5;241m=\u001b[39mdaterange,\n\u001b[1;32m      4\u001b[0m     collections\u001b[38;5;241m=\u001b[39m[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mrema\u001b[39m\u001b[38;5;124m\"\u001b[39m],\n\u001b[1;32m      5\u001b[0m     limit\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m500\u001b[39m,      \u001b[38;5;66;03m# number of items per page of results\u001b[39;00m\n\u001b[1;32m      6\u001b[0m     max_items\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1e9\u001b[39m,  \u001b[38;5;66;03m# abritrarily large max_items to return.\u001b[39;00m\n\u001b[1;32m      7\u001b[0m )\n",
+      "File \u001b[0;32m~/software/miniconda3/envs/geomamba/lib/python3.10/site-packages/pystac_client/client.py:422\u001b[0m, in \u001b[0;36mClient.search\u001b[0;34m(self, method, max_items, limit, ids, collections, bbox, intersects, datetime, query, filter, filter_lang, sortby, fields)\u001b[0m\n\u001b[1;32m    321\u001b[0m \u001b[38;5;124;03m\"\"\"Query the ``/search`` endpoint using the given parameters.\u001b[39;00m\n\u001b[1;32m    322\u001b[0m \n\u001b[1;32m    323\u001b[0m \u001b[38;5;124;03mThis method returns an :class:`~pystac_client.ItemSearch` instance. See that\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    419\u001b[0m \u001b[38;5;124;03m        a ``\"rel\"`` type of ``\"search\"``.\u001b[39;00m\n\u001b[1;32m    420\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    421\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_conforms_to(ConformanceClasses\u001b[38;5;241m.\u001b[39mITEM_SEARCH):\n\u001b[0;32m--> 422\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mNotImplementedError\u001b[39;00m(\n\u001b[1;32m    423\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mThis catalog does not support search because it \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    424\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mdoes not conform to \u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mConformanceClasses\u001b[38;5;241m.\u001b[39mITEM_SEARCH\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    425\u001b[0m     )\n\u001b[1;32m    426\u001b[0m search_link \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mget_search_link()\n\u001b[1;32m    427\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m search_link:\n",
+      "\u001b[0;31mNotImplementedError\u001b[0m: This catalog does not support search because it does not conform to \"ConformanceClasses.ITEM_SEARCH\""
+     ]
+    }
+   ],
+   "source": [
+    "stac.search(\n",
+    "    intersects=aoi_geom_4326,\n",
+    "    datetime=daterange,\n",
+    "    collections=[\"rema\"],\n",
+    "    limit=500,      # number of items per page of results\n",
+    "    max_items=1e9,  # abritrarily large max_items to return.\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (geomamba)",
+   "language": "python",
+   "name": "geomamba"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Example jupyter notebook code contributed by Tom Chudley for downloading REMA data from the AWS STAC catalog. Notebook showcases an error he received when trying to execute a spatial query on the catalog, because the current STAC implementation on AWS is a static catalog and not a dynamic STAC server.