### PR TITLE
Rebuild strip DEMs scene metadata from .mdf files

### DIFF
--- a/index_setsm.py
+++ b/index_setsm.py
@@ -197,7 +197,7 @@ def main():
         parser.error("--project option is required if when mode=tile")
 
     if args.mode == 'strip' and args.use_release_fields and not args.project:
-        parser.error("--project option is required if when mode=strip wit--use-release-fields")
+        parser.error("--project option is required when mode=strip using --use-release-fields")
 
     if args.mode == 'scene' and args.use_release_fields:
         parser.error("--use-release-fields option is not applicable to mode=scene")

--- a/lib/dem.py
+++ b/lib/dem.py
@@ -860,7 +860,6 @@ class SetsmDem(object):
 
         ## If metafile exists
         if self.metapath:
-            ## TODO make an attribute of the metad dict without the scenes
             metad = self._parse_metadata_file()
 
             self.scenes = metad['scene_list']
@@ -981,7 +980,6 @@ class SetsmDem(object):
 
         ## If mdf exists without metafile
         elif os.path.isfile(self.mdf):
-            ## TODO make an attribute of the metad dict without the scenes
             metad = self._read_mdf_file()
 
             ## populate attribs
@@ -1069,6 +1067,30 @@ class SetsmDem(object):
                 pass
             else:
                 self.reginfo_list.append(RegInfo(dx, dy, dz, num_gcps, mean_resid_z, None, name))
+
+            ## rebuild scene dem alignment dictionary
+            alignment_keys = [
+                'rmse',
+                'dz',
+                'dx',
+                'dy',
+                'dz_err',
+                'dx_err',
+                'dy_err',
+            ]
+
+            self.alignment_dct = dict()
+            scene_num = 1
+            while scene_num:
+                skey = f'COMPONENT_{scene_num}_sceneDemId'
+                if skey in metad:
+                    akeys = [f'COMPONENT_{scene_num}_MOSAIC_ALIGNMENT_{ak}' for ak in alignment_keys]
+                    self.alignment_dct[metad[skey]] = [metad[akey] for akey in akeys if akey in metad]
+                    scene_num += 1
+                else:
+                    scene_num = None
+
+            self._set_rmse_attrib()
 
         else:
             raise RuntimeError("Neither meta.txt nor mdf.txt file exists for DEM: {}".format(self.srcfp))


### PR DESCRIPTION
This PR fixes a bug where the alignment statistics for the component scene DEMs were not being gathered when a DEM object was built from mdf file instead of the original txt file.  This resulted in missing index attributes. This PR also adds a test for field and value parity between indexes built with either method.