### PR TITLE
add bitmask as component option to resample_setsm.py

### DIFF
--- a/resample_setsm.py
+++ b/resample_setsm.py
@@ -12,7 +12,7 @@ logger.setLevel(logging.INFO)
 
 strip_pattern = re.compile("SETSM_(?P<pairname>(?P<sensor>[A-Z]{2}\d{2})_(?P<timestamp>\d{8})_(?P<catid1>[A-Z0-9]{16})_(?P<catid2>[A-Z0-9]{16}))_(?P<partnum>\d+)_(?P<res>\d+m)_matchtag.tif", re.I)
 default_res = 16
-suffixes = ('matchtag', 'dem')
+suffixes = ('matchtag', 'dem', 'bitmask')
 
 submission_script_map = {
     'pbs': 'pbs_resample.sh',


### PR DESCRIPTION
Allow the resampling of `_bitmask.tif` images to different resolutions using the nearest neighbor method.