### PR TITLE
package strip rasterproxy completeness bug

### DIFF
--- a/package_setsm.py
+++ b/package_setsm.py
@@ -162,7 +162,7 @@ def main():
                     expected_outputs.append(cog_sem)
                 if not args.skip_archive:
                     expected_outputs.append(raster.archive)
-                if args.rasterproxy_prefix:
+                if args.build_rasterproxies:
                     # this checks for only 1 of the several rasterproxies that are expected
                     expected_outputs.append(rp)
 

--- a/slurm_package.sh
+++ b/slurm_package.sh
@@ -9,11 +9,12 @@
 ## memory per job
 #SBATCH --mem 4gb
 ## licenses (per filesystem limit)
-#SBATCH --licenses vida:200
+#SBATCH --licenses vida:150
 ## gres (per node bandwidth limit)
 #SBATCH --gres bandwidth:1000
 ## job log path
 #SBATCH -o %x.%j.out
+#SBATCH --nice=10000
 
 echo ________________________________________
 echo


### PR DESCRIPTION
Problem: package_setsm.py would never call a strip complete if rasterproxies were not built.
Solution: checked for the correct argument.