### PR TITLE
Adapt for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,22 @@ allows the given tool to operate on several tasks at once.
 pgcdemtools uses pytest for running tests. Some use large files that are not included in the git repo, but are available
 upon request
 
-On Linux systems:
+On Linux systems, make a symlink to the test data location:
 ```sh
 # first time only
 ln -s <test_data_location>/tests/testdata tests/
 
 # run the tests
-pytest 
+pytest
+```
+
+On Windows, you have to use the full network path and not a mounted drive letter path:
+```sh
+# first time only
+mklink /d tests\testdata <\\server.school.edu\test_data_location>\tests\testdata
+
+# run the tests
+pytest
 ```
 
 ## Contact

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -560,7 +560,7 @@ def get_source_names(src_fp):
         _src_fp = src_fp
         src_lyr = os.path.splitext(os.path.basename(src_fp))[0]
     elif ".gdb" in src_fp.lower() and not src_fp.lower().endswith(".gdb"):
-        _src_fp, src_lyr = re.split(r"(?<=\.gdb)/", src_fp, re.I)
+        _src_fp, src_lyr = os.path.split(src_fp)
     else:
         msg = "The source {} does not appear to be a Shapefile, File GDB, or GeoPackage -- quitting".format(src_fp)
         raise RuntimeError(msg)
@@ -581,7 +581,7 @@ def get_source_names2(src_str):
     elif ".gdb" in src_str.lower():
         driver = ["FileGDB", "OpenFileGDB"]
         if not src_str_abs.lower().endswith(".gdb"):
-            src_ds, src_lyr = re.split(r"(?<=\.gdb)/", src_str_abs, re.I)
+            src_ds, src_lyr = os.path.split(src_str_abs)
         else:
             src_ds = src_str
             src_lyr = os.path.splitext(os.path.basename(src_str))[0]
@@ -589,7 +589,7 @@ def get_source_names2(src_str):
     elif ".gpkg" in src_str.lower():
         driver = ["GPKG"]
         if not src_str_abs.lower().endswith(".gpkg"):
-            src_ds, src_lyr = re.split(r"(?<=\.gpkg)/", src_str_abs, re.I)
+            src_ds, src_lyr = os.path.split(src_str_abs)
         else:
             src_ds = src_str
             src_lyr = os.path.splitext(os.path.basename(src_str))[0]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,10 +1,12 @@
 import argparse
 import glob
 import os
+import platform
 import shutil
 import subprocess
 import unittest
 
+import pytest
 from osgeo import gdal, gdalconst
 
 try:
@@ -16,7 +18,7 @@ __test_dir__ = os.path.dirname(__file__)
 testdata_dir = os.path.join(__test_dir__, 'testdata')
 __app_dir__ = os.path.dirname(__test_dir__)
 
-
+@pytest.mark.skipif(platform.system() == "Windows", reason="Not applicable on Windows")
 class TestPackagerStrips(unittest.TestCase):
 
     def setUp(self):
@@ -81,7 +83,7 @@ class TestPackagerStrips(unittest.TestCase):
                 except AssertionError as e:
                     self.assertIn(msg, se.decode())
 
-
+@pytest.mark.skipif(platform.system() == "Windows", reason="Not applicable on Windows")
 class TestPackagerTiles(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Problem: After conversion to pytest, some tests failed on windows.

Solution: Repaired tests where possible and added skip markers if the tested functionality is not used on windows.