### PR TITLE
Make project arg required only when absolutely necessary for index_setsm.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,8 @@ package_setsm_tiles - Build an index of a SETSM DEM mosaic tiles or directory of
 into tar.gz archives.
 
 ### Shelve
-shelve_setsm_by_date - Move or copy a SETSM DEM or a directory of DEMs into folders based on acquisition date.
-
-shelve_setsm_by_geocell - Move or copy a SETSM DEM or a directory of DEMs into folders based on the geocell that 
-intersects with the DEM centroid, as identified by the lower left geocell corner.
-
-shelve_setsm_by_shp - Move or copy a SETSM DEM or a directory of DEMs into folders based on a custom shapefile index.
+shelve_setsm_simple - Move or copy a SETSM DEM or a directory of DEMs into folders based on acquisition date, the 
+geocell that intersects with the DEM centroid as identified by the lower left geocell corner, or a custom shapefile index.
 
 ### Retrieve
 copy_dems - Copy DEMs using a subset of the DEM index built using index_setsm.py.

--- a/index_setsm.py
+++ b/index_setsm.py
@@ -154,7 +154,8 @@ def main():
     parser.add_argument("--write-pickle", help="store region lookup in a pickle file. skipped if --write-json is used")
     parser.add_argument("--read-pickle", help='read region lookup from a pickle file. skipped if --write-json is used')
     parser.add_argument("--custom-paths", choices=custom_path_prefixes.keys(), help='Use custom path schema')
-    parser.add_argument('--project', choices=utils.PROJECTS.keys(), help='project name (required when writing tiles)')
+    parser.add_argument('--project', choices=utils.PROJECTS.keys(), help='project name (required when '
+                                                                         'writing tile jsons or with --use-release-fields)')
     parser.add_argument('--debug', action='store_true', default=False, help='print DEBUG level logger messages to terminal')
     parser.add_argument('--dryrun', action='store_true', default=False, help='run script without inserting records')
     parser.add_argument('--np', action='store_true', default=False, help='do not print progress bar')
@@ -193,8 +194,8 @@ def main():
         parser.error('--check cannot be used with the --write-json option')
 
     ## Check project
-    if args.mode == 'tile' and not args.project:
-        parser.error("--project option is required if when mode=tile")
+    if args.mode == 'tile' and (args.write_json or args.use_release_fields) and not args.project:
+        parser.error("--project option is required when mode=tile using --write-json or --use-release-fields")
 
     if args.mode == 'strip' and args.use_release_fields and not args.project:
         parser.error("--project option is required when mode=strip using --use-release-fields")

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -843,13 +843,13 @@ class TestIndexerTiles(unittest.TestCase):
         test_param_list = (
             # input, output, args, result feature count, message
             (os.path.join(self.tile_dir, 'v3', '33_11'), self.test_str,
-             '--project arcticdem', 3, 'Done'),  # test 100x100km tile at 3 resolutions
+             '', 3, 'Done'),  # test 100x100km tile at 3 resolutions
             (os.path.join(self.tile_dir, 'v3', '33_11_quartertiles'), self.test_str,
-             '--overwrite --project arcticdem', 4, 'Done'),  # test quartertiles formatted for release
+             '--overwrite', 4, 'Done'),  # test quartertiles formatted for release
             (os.path.join(self.tile_dir, 'v4', '59_57'), self.test_str,
-             '--overwrite --check --project arcticdem', 4, 'Done'),  # test v4 tiles, 2m
+             '--overwrite --check', 4, 'Done'),  # test v4 tiles, 2m
             (os.path.join(self.tile_dir, 'v4', 'utm34n_60_06'), self.test_str,
-             '--overwrite --project earthdem', 4, 'Done'),  # test v4 utm tiles, 2m
+             '--overwrite', 4, 'Done'),  # test v4 utm tiles, 2m
         )
 
         for i, o, options, result_cnt, msg in test_param_list:
@@ -922,6 +922,28 @@ class TestIndexerTiles(unittest.TestCase):
 
     # @unittest.skip("test")
     def testTilev4Json(self):
+        ## Test project is required for json creation
+        cmd = 'python {}/index_setsm.py --np {} {} --mode tile --write-json'.format(
+            __app_dir__,
+            os.path.join(self.tile_dir, 'v4', '59_57'),
+            self.output_dir,
+        )
+        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (so, se) = p.communicate()
+        # print(se)
+        # print(so)
+
+        json_list = [
+            'arcticdem_59_57_2m.json',
+        ]
+
+        for json_fn in json_list:
+            json = os.path.join(self.output_dir, json_fn)
+            self.assertFalse(os.path.isfile(json))
+        ## Test if stdout has proper error
+        msg = "--project option is required when mode=tile using --write-json or --use-release-fields"
+        self.assertIn(msg, se.decode())
+
         ## Test json creation
         cmd = 'python {}/index_setsm.py --np {} {} --mode tile --project arcticdem --write-json'.format(
             __app_dir__,
@@ -942,7 +964,7 @@ class TestIndexerTiles(unittest.TestCase):
             self.assertTrue(os.path.isfile(json))
 
         ## Test json read
-        cmd = 'python {}/index_setsm.py --np {} {} --mode tile --project arcticdem --read-json'.format(
+        cmd = 'python {}/index_setsm.py --np {} {} --mode tile --read-json'.format(
             __app_dir__,
             self.output_dir,
             self.test_str,
@@ -977,7 +999,7 @@ class TestIndexerTiles(unittest.TestCase):
         self.assertTrue(os.path.isfile(json))
 
         ## Test json read
-        cmd = 'python {}/index_setsm.py --np {} {} --mode tile --project arcticdem --read-json'.format(
+        cmd = 'python {}/index_setsm.py --np {} {} --mode tile --read-json'.format(
             __app_dir__,
             self.output_dir,
             self.test_str,


### PR DESCRIPTION
This is needed so FRIDGE can pull tiles without knowing the project.